### PR TITLE
docs: recover minimal defensible documentation set

### DIFF
--- a/docs/api/generator_cli.md
+++ b/docs/api/generator_cli.md
@@ -1,9 +1,108 @@
-# `src/generator/cli.py`
-::: generator.cli
+# CLI: `generator.cli` (synthetic instance generator)
 
-## Public API (frozen)
-`build_graph(rng, num_nodes, density) -> networkx.Graph`
+The `generator` module implements the **synthetic instance generator** used throughout the project.
+It is responsible for creating graphs with controlled properties, such as:
 
-- Conectividade garantida (árvore base + arestas extras).
-- Densidade final, quando necessário: `2m/(n*(n-1))`.
-- Modularidade pode ser `null` em grafos grandes (política de performance).
+- number of vertices;
+- edge density or related connectivity parameters;
+- degree / “speed” heterogeneity (coefficient-of-variation bands);
+- other structural features relevant for the experimental design.
+
+Generated instances are stored as JSON documents (optionally gzip-compressed) that conform to the
+input schema:
+
+```text
+specs/schema_input.json
+````
+
+These files are later consumed by the core operators and external solvers via the
+`hpc_framework` runner.
+
+---
+
+## Invoking the CLI
+
+After installing the project (preferably via Poetry), the generator can be inspected with:
+
+```bash
+poetry run python -m generator.cli --help
+```
+
+This command prints the available subcommands and options, including:
+
+* how to choose the number of nodes;
+* how to control density / sparsity;
+* how to select variability regimes (e.g. degree or “speed” heterogeneity);
+* how to fix RNG seeds;
+* how to select the output path and compression.
+
+The exact flag names and defaults may evolve with the project; the `--help` output is the
+authoritative source for the current version.
+
+---
+
+## Output format and location
+
+By convention, synthetic instances are stored under:
+
+```text
+data/instances/synthetic/
+```
+
+For example, a file named:
+
+```text
+data/instances/synthetic/n2000_p50.json.gz
+```
+
+encodes a graph with roughly 2000 vertices and a target density of about 0.50,
+together with any additional attributes required by the experimental protocol (e.g. vertex weights).
+
+Each JSON instance is validated against `specs/schema_input.json` during the pipeline, ensuring that:
+
+* required fields are present and properly typed;
+* user-defined regimes (e.g. number of nodes, density bands) are honoured within tolerance;
+* the graph structure is consistent (e.g. no malformed edges, basic connectivity checks).
+
+---
+
+## Batch generation via configuration
+
+While individual instances can be generated directly from the CLI, the typical workflow for
+experiments is **batch-oriented**:
+
+1. A configuration file (e.g. `configs/instances_to_generate.yaml`) defines regimes and targets:
+
+   * node counts;
+   * density / sparsity regimes;
+   * heterogeneity bands;
+   * number of instances per regime.
+
+2. A pipeline script (e.g. one of the helpers under `scripts/`) reads this configuration and
+   calls the generator CLI repeatedly, materialising a panel of instances under `data/instances/`.
+
+3. Experiment plans (such as `configs/plan_phase_1.yaml`) refer to these generated instances
+   when defining the instance panel for each phase.
+
+The exact pipeline script and YAML layout are documented in more detail in the *Instance generator*
+report under `docs/reports/`.
+
+---
+
+## Design goals
+
+The generator is designed to support the following goals:
+
+* **Control**: allow precise control over graph regimes used in benchmarking.
+* **Reproducibility**: expose explicit seeding and configuration so that panels can be
+  reconstructed from YAML and logs.
+* **Compatibility**: produce instances that are immediately compatible with the partitioning
+  pipeline (no ad-hoc conversion steps).
+
+For details of the underlying models and validation procedures, refer to:
+
+* `docs/reports/01_instance_generator.md` (conceptual overview and validation);
+* `specs/bounds.json` and related specification files.
+
+```
+```

--- a/docs/reports/01_instance_generator.md
+++ b/docs/reports/01_instance_generator.md
@@ -1,27 +1,197 @@
-# Metodologia do Gerador de Instâncias (v4.0)
+# Instance generator: design and validation
 
-## 1. Objetivo
-O gerador de instâncias foi projetado para produzir grafos sintéticos para o benchmarking de heurísticas de clusterização. O design prioriza o controle paramétrico rigoroso, a reprodutibilidade e a escalabilidade, conforme definido no protocolo `proto_v3.1.1`.
+This report documents the synthetic instance generator used in the FORJA / HPC Framework project.
+The generator is responsible for producing graphs with controlled properties, which are later used
+to benchmark partitioning algorithms under fair and reproducible conditions.
 
-## 2. Metodologia de Geração de Grafo
-Para garantir a conectividade e a densidade alvo de forma eficiente, a construção do grafo segue um processo de duas etapas:
-1.  **Garantia de Conectividade:** Uma árvore geradora aleatória (`random_labeled_tree` do NetworkX) é criada com `N` nós. Por definição, este grafo inicial é conexo e possui `N-1` arestas.
-2.  **Ajuste de Densidade:** Arestas adicionais são inseridas aleatoriamente no grafo de forma iterativa e vetorizada, sem permitir laços ou arestas paralelas, até que o número total de arestas atinja o alvo definido pela densidade solicitada. Esta abordagem O(m) garante performance para grafos grandes e densos.
+The generator is implemented as a Python module under:
 
-## 3. Metodologia de Geração de Velocidades
-Para gerar velocidades de veículos com um Coeficiente de Variação (CV) alvo, foi implementada uma abordagem híbrida:
-1.  **Distribuição Beta Reescalada:** Para CVs baixos e médios, amostras são retiradas de uma distribuição Beta cujos parâmetros (alpha, beta) são calculados para corresponder à média e variância desejadas. As amostras, no intervalo [0, 1], são então reescaladas para o intervalo de velocidades do protocolo [V_MIN, V_MAX].
-2.  **Fallback Bimodal:** Se o CV alvo for matematicamente inatingível pela distribuição Beta, o sistema aciona um fallback para um método bimodal que distribui os veículos em dois grupos (velocidades próximas de V_MIN e V_MAX) para garantir a alta variância solicitada.
+```text
+src/generator/
+````
 
-## 4. Interface de Uso (CLI)
-O gerador é controlado via linha de comando, aceitando os seguintes parâmetros:
-- `--nodes`: ...
-- `--density`: ...
-- `--cv-vel`: ...
-- `--output`: ...
-- `--epsilon`: ...
-- `--seed`: ...
-- `--verbose`: ...
+and exposed via a command-line interface (CLI) described in the *API → Instance generator CLI*
+section of this site.
 
-## 5. Formato de Saída e Validação
-A saída é um arquivo JSON único que adere a um schema formal (`specs/schema_input.json`). Antes de salvar, o gerador realiza uma validação automática para garantir a conformidade... (etc.)
+---
+
+## 1. Goals and design principles
+
+The instance generator is designed to support the following goals:
+
+1. **Control**
+   Allow experiments to target specific regimes of:
+
+   * number of vertices `n`;
+   * edge density / sparsity;
+   * degree or “speed” heterogeneity (coefficient of variation);
+   * other structural features relevant to the algorithm-selection study.
+
+2. **Reproducibility**
+   Ensure that a panel of graphs can be reconstructed from:
+
+   * a versioned configuration file (YAML);
+   * a fixed code revision;
+   * explicit random seeds.
+
+3. **Compatibility**
+   Produce instances that conform to the input JSON schema used by the rest of the framework,
+   so that no ad-hoc conversion is needed before running solvers.
+
+The generator is not a general-purpose random graph library; it is tailored to the needs of the
+graph partitioning experiments in this project.
+
+---
+
+## 2. Input and output formats
+
+### 2.1. Input JSON schema
+
+Generated instances are stored as JSON documents (optionally gzip-compressed, `*.json.gz`)
+that conform to the **input schema**:
+
+```text
+specs/schema_input.json
+```
+
+This schema defines, among other things:
+
+* basic metadata (instance identifier, generator configuration);
+* the list of vertices and their attributes (e.g. weights);
+* the list of edges and their attributes;
+* invariants required by the partitioning operators (e.g. no self-loops, indexing conventions).
+
+Downstream components (core operators, external solvers) assume that this schema is satisfied.
+Sanity tests in `tests/test_instances_sanity.py` and related modules enforce this contract.
+
+### 2.2. Output location and naming convention
+
+By convention, synthetic instances are stored under:
+
+```text
+data/instances/synthetic/
+```
+
+A typical filename encodes the main regime parameters, for example:
+
+* `n2000_p50.json.gz` – about 2000 vertices, target density around 0.50;
+* `n2000_dense_fast.json.gz` – a denser regime with different heterogeneity;
+* `n3000_p35_cv045.json.gz` – explicit mention of CV bands in the filename.
+
+These files are small enough to be versioned as part of the repository (or via Git LFS),
+and are used both as examples and as part of the Phase 1 experimental panel.
+
+---
+
+## 3. Regimes and configuration (`configs/instances_to_generate.yaml`)
+
+Rather than generating graphs purely ad hoc from individual CLI calls, this project relies on a
+**configuration-driven approach**.
+
+The file:
+
+```text
+configs/instances_to_generate.yaml
+```
+
+defines a set of **regimes** to be generated. Each regime typically specifies:
+
+* target number of nodes;
+* target density or related metric;
+* degree / “speed” heterogeneity bands (via coefficient of variation);
+* number of instances per regime;
+* random seeds or ranges.
+
+The exact field names and structure are documented inside the YAML file itself. The generator
+reads this configuration and materialises each regime as one or more JSON instances under
+`data/instances/`.
+
+This design allows:
+
+* regenerating the same panel of instances on a new machine, given the YAML and a fixed code revision;
+* extending the panel (e.g. adding new regimes) without changing the generator logic;
+* documenting the experimental landscape in a single, version-controlled file.
+
+---
+
+## 4. CLI usage (high-level)
+
+The generator exposes a CLI entry point under the `generator` module. After installing the
+project (preferably via Poetry), the general pattern is:
+
+```bash
+poetry run python -m generator.cli --help
+```
+
+The `--help` output describes the available subcommands and options, including:
+
+* how to select the number of nodes;
+* how to control density or related parameters;
+* how to pick heterogeneity regimes (e.g. CV bands);
+* how to set seeds for reproducibility;
+* how to choose the output path and compression.
+
+For generating a small number of instances manually, a simple one-shot invocation is usually
+sufficient (for example, targeting a specific `n` and density). For full experimental panels,
+the recommended workflow is to:
+
+1. edit `configs/instances_to_generate.yaml` to define or adjust regimes;
+2. use a pipeline script under `scripts/` to iterate over those regimes and call the generator
+   CLI programmatically;
+3. verify the resulting panel via the test suite (see Section 5).
+
+The exact argument names and subcommands may evolve with the project; the CLI `--help` output is
+the authoritative source for the current version.
+
+---
+
+## 5. Validation and test coverage
+
+A dedicated set of tests under `tests/` validates both individual instances and the behaviour of
+the generator across regimes. Key modules include:
+
+* `tests/test_generator.py`
+  Basic properties of generated instances and integration with the CLI.
+
+* `tests/test_degree_cv_bands.py`
+  Ensures that generated instances fall within the intended **coefficient-of-variation bands**
+  for degree or “speed” distributions, as specified by the configuration.
+
+* `tests/test_degree_cv_cap.py`
+  Enforces **ceiling constraints** on variability, preventing the generator from producing
+  instances that are too heterogeneous for the experimental design.
+
+* `tests/test_instances_sanity.py`
+  General structural sanity checks (e.g. no malformed edges, consistent indexing), aligned with
+  the expectations encoded in `specs/schema_input.json`.
+
+* `tests/test_modularity_gate_regression.py`
+  Regression tests related to modularity estimates and gates used to filter or classify instances
+  by community structure.
+
+Together, these tests act as a safety net: changes to the generator or to the configuration are
+flagged early if they break the intended regimes or violate basic invariants.
+
+---
+
+## 6. Relation to the experimental protocol
+
+The instance generator is a **preparatory stage** for the experimental protocol described in:
+
+* `docs/protocol/proto_v3.1.1.md`;
+* `configs/plan_phase_1*.yaml` (experiment plans);
+* the Phase 1 campaign report (`docs/reports/02_experimental_campaign.md`).
+
+The typical high-level workflow is:
+
+1. **Generate or refresh** the synthetic panel under `data/instances/` using the generator and
+   `configs/instances_to_generate.yaml`.
+2. **Run experiments** (e.g. Phase 1) via the `hpc_framework` CLI and the appropriate plan file.
+3. **Pack, validate and aggregate** results into manifests and CSV tables.
+
+By keeping generator configuration, instance files, plans and results all under version control
+(or tracked via Git LFS and audit bundles), the project ensures that the experimental landscape
+is fully specified and can be reconstructed when needed.
+
+```
+```

--- a/docs/testing/CI.md
+++ b/docs/testing/CI.md
@@ -1,17 +1,222 @@
-- name: Run pytest + coverage
-  run: poetry run pytest
+````markdown
+# Continuous Integration (CI)
 
-- name: Upload coverage.xml
-  uses: actions/upload-artifact@v4
-  with:
-    name: coverage-xml
-    path: coverage.xml
+This document describes the minimal Continuous Integration (CI) pipeline configured for the
+FORJA / HPC Framework repository.
 
-# (opcional) construir docs
-- name: Build docs
-  run: poetry run mkdocs build
-- name: Upload site
-  uses: actions/upload-artifact@v4
+The CI is implemented via GitHub Actions and defined in:
+
+```text
+.github/workflows/ci.yml
+````
+
+---
+
+## 1. Triggers and scope
+
+The workflow is named **"CI (minimal)"** and is triggered on:
+
+* any `push` to any branch (`branches: ['**']`), ignoring changes under `site/**`;
+* any `pull_request` targeting `main` or `dev`, also ignoring `site/**`.
+
+This ensures that:
+
+* every commit pushed to the repository gets basic QA checks;
+* every PR into the protected branches (`main`, `dev`) runs the same pipeline.
+
+A `concurrency` block groups runs by `ref`:
+
+```yaml
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+so that older runs for the same branch/PR are cancelled when a new commit arrives.
+
+---
+
+## 2. Job: `tests`
+
+The workflow defines a single job, `tests`, which runs on **Ubuntu 22.04**:
+
+```yaml
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+```
+
+The steps in this job are:
+
+### 2.1. Checkout with Git LFS
+
+```yaml
+- name: Checkout (with LFS)
+  uses: actions/checkout@v4
   with:
-    name: site
-    path: site
+    fetch-depth: 0
+    lfs: true
+```
+
+This checkout:
+
+* fetches the full history (`fetch-depth: 0`), which is useful for some tools;
+* enables Git LFS, so that large files (e.g. instances under `data/instances/`) are available.
+
+### 2.2. Ensure Git LFS and materialise blobs
+
+```yaml
+- name: Ensure Git LFS & materialize blobs
+  run: |
+    set -euxo pipefail
+    if ! command -v git-lfs >/dev/null 2>&1; then
+      sudo apt-get update
+      sudo apt-get install -y git-lfs
+    fi
+    git lfs version
+    git lfs install --local
+    git lfs fetch --all
+    git lfs checkout
+    git lfs ls-files || true
+    ls -lh data/instances/synthetic || true
+    if grep -R -n "version https://git-lfs.github.com/spec/v1" data/instances/synthetic/*.json.gz >/dev/null 2>&1; then
+      echo "ERROR: still seeing LFS pointers in *.json.gz" >&2
+      exit 2
+    fi
+```
+
+Purpose:
+
+* guarantee that Git LFS is installed and configured;
+* fetch and checkout all LFS objects;
+* list LFS-tracked files and the synthetic instance directory;
+* **fail fast** if any `*.json.gz` under `data/instances/synthetic/` is still an LFS pointer
+  instead of a real gzip payload.
+
+This prevents corrupted or placeholder instances from entering the test pipeline.
+
+### 2.3. GZIP sanity check
+
+```yaml
+- name: GZIP sanity (gzip -t)
+  run: |
+    set -e
+    shopt -s nullglob
+    files=(data/instances/synthetic/*.json.gz)
+    if [ ${#files[@]} -eq 0 ]; then
+      echo "No *.json.gz in data/instances/synthetic" >&2
+      exit 2
+    fi
+    for f in "${files[@]}"; do
+      echo "Testing gzip: $f"
+      if ! gzip -t "$f"; then
+        echo "Corrupted file or LFS pointer: $f" >&2
+        head -c 64 "$f" | sed 's/[^[:print:]]/./g' || true
+        exit 2
+      fi
+    done
+    echo "GZIP OK"
+```
+
+This step:
+
+* ensures there is at least one `*.json.gz` in the synthetic instances directory;
+* runs `gzip -t` on each file, failing if any is invalid;
+* prints a small diagnostic prefix for corrupted files.
+
+Together with the previous step, this enforces **LFS + gzip integrity** for the synthetic panel.
+
+### 2.4. Python setup
+
+```yaml
+- name: Setup Python
+  uses: actions/setup-python@v5
+  with:
+    python-version: "3.11"
+    cache: "pip"
+    cache-dependency-path: |
+      pyproject.toml
+      setup.cfg
+      setup.py
+```
+
+This configures Python 3.11 with pip caching, keying the cache on the dependency descriptors.
+
+### 2.5. System dependencies (METIS)
+
+```yaml
+- name: System deps (METIS for gpmetis)
+  run: |
+    sudo apt-get update
+    sudo apt-get install -y metis
+    gpmetis -h | head -n1 || true
+```
+
+This installs the `metis` package and checks that `gpmetis` is callable. KaHIP is not installed
+in this minimal job; tests that require it are excluded by the pytest selection.
+
+### 2.6. Python dependencies (pip-only)
+
+```yaml
+- name: Install Python deps (pip only)
+  run: |
+    python -m pip install --upgrade pip
+    pip install -U pytest
+    pip install .
+```
+
+This:
+
+* upgrades `pip`;
+* installs `pytest`;
+* installs the current project into the environment via `pip install .`.
+
+Unlike local development, CI does not use Poetry here; this keeps the workflow minimal while
+still respecting `pyproject.toml`.
+
+### 2.7. Run tests
+
+```yaml
+- name: Run tests
+  env:
+    OMP_NUM_THREADS: "1"
+    OPENBLAS_NUM_THREADS: "1"
+    MKL_NUM_THREADS: "1"
+  run: pytest -q -k "not (kahip or solvers_external)"
+```
+
+The final step:
+
+* enforces **single-threaded execution** for numerical backends (OMP / BLAS / MKL);
+* runs pytest in quiet mode;
+* **excludes** tests related to KaHIP and heavy external-solver integration, keeping the pipeline
+  fast and robust across environments.
+
+A more exhaustive suite (including KaHIP and extended solver tests) is expected to be run
+locally by developers when the appropriate solvers are installed.
+
+---
+
+## 3. Relation to branch policy and contributions
+
+The repository follows a simple contribution workflow:
+
+* feature branches are created from `dev`;
+* pull requests target `dev` (not `main`);
+* CI must pass before merging;
+* `dev` is merged into `main` via pull request, and the `main` branch is protected.
+
+The CI workflow acts as a **gatekeeper** for:
+
+* LFS / gzip integrity of synthetic instances;
+* basic installation viability (`pip install .`);
+* the core test suite (with external-solver-heavy tests excluded in this minimal job).
+
+Developers are encouraged to:
+
+* run tests locally via Poetry (`poetry run pytest ...`);
+* use `pre-commit` hooks for fast feedback on style and basic QA;
+* keep `.github/workflows/ci.yml` and `docs/testing/*.md` aligned when the testing strategy evolves.
+
+```
+```

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -1,99 +1,223 @@
-# Guia de Testes
+````markdown
+# Testing strategy
 
-> Escopo inicial: **gerador de instâncias** (CLI, JSON-first, schema v1.1, políticas de modularidade e CV)
-> Futuro próximo: runner/orquestrador, métricas, pipelines de campanha.
+This document summarises how tests are organised in the FORJA / HPC Framework project and how to
+run them locally in a way that mirrors the CI pipeline.
 
-## Como executar localmente
+The overall philosophy is:
+
+- keep a **fast, always-green smoke subset**;
+- maintain a **broader regression suite** (unit, schema, integration);
+- keep external solver tests explicit (METIS / KaHIP), so the suite can still run in
+  constrained environments.
+
+---
+
+## 1. Test types
+
+Tests live under:
+
+```text
+tests/
+````
+
+and are organised roughly as follows:
+
+* **Smoke and sanity layers**
+
+  * `tests/test_sanity.py`
+  * `tests/test_runner_smoke.py`
+  * `tests/test_solvers_smoke.py`
+
+* **Core functionality**
+
+  * `tests/test_generator.py`
+  * `tests/test_operator.py`
+  * `tests/test_heuristics_metrics.py`
+  * `tests/test_public_api.py`
+
+* **Schema and contracts**
+
+  * `tests/test_results_schema.py`
+  * `tests/test_instances_sanity.py`
+
+* **Regime-specific constraints**
+
+  * `tests/test_degree_cv_bands.py`
+  * `tests/test_degree_cv_cap.py`
+  * `tests/test_modularity_gate_regression.py`
+
+* **External solvers**
+
+  * `tests/test_solvers_external.py`
+  * tests tagged or filtered as `"kahip"` in the CI selection.
+
+Not all tests run in every environment. The CI configuration and some local commands use pytest
+expressions to **exclude slower or solver-specific tests** when appropriate.
+
+---
+
+## 2. Running tests locally (Poetry environment)
+
+The canonical way to run tests locally is via **Poetry**, using the locked environment
+(`poetry.lock`).
+
+From the repository root:
 
 ```bash
-poetry install --no-interaction
-pytest -q
-# testes mais lentos/opcionais
-pytest -m "slow" -q
-````
+poetry install --with dev -E metrics
+```
 
-**Ambiente alvo:** Python 3.11. `PYTHONHASHSEED=0`. Não exigimos mono-thread de BLAS para unit tests.
+### 2.1. Full (local) suite, mirroring CI selection
 
-## Padrões
+The minimal suite used in CI excludes KaHIP and external-solver tests:
 
-* Seeds fixas em testes estocásticos.
-* Artefatos em diretórios efêmeros (`tmp_path`), **sem** poluir `data/instances`.
-* Estilo *Arrange–Act–Assert* / *Given–When–Then*.
-* Mensagens de falha claras e parametrização (`@pytest.mark.parametrize`) quando couber.
-
-## Marcadores
-
-* `@pytest.mark.schema` — validações de schema/contrato.
-* `@pytest.mark.cli` — invocação do CLI e parsing leve.
-* `@pytest.mark.slow` — cenários maiores, ou smoke de desempenho.
-* `@pytest.mark.docs` — verificação de exemplos do README/docs.
-
-## O que é coberto agora
-
-* JSON-first validado (schema v1.1).
-* Gate de modularidade → `modularity: null` quando limite for excedido.
-* Teto de CV (média no centro) = **1/3** com *warning* quando capado.
-* Exemplos mínimos de CLI do README executam (smoke).
-
-## O que entra em seguida
-
-* Freeze de schemas versionados em `specs/1.1/...` e teste dedicado.
-* Smoke de desempenho com limites suaves (sem quebrar CI).
-* Testes do runner/orquestrador (quando estabilizar interface).
-
-## Métricas de qualidade (indicativas)
-
-* Cobertura prática 70–80% em `src/generator/*` (excluindo logs e trilhas de erro raras).
-* Zero *flake* em testes determinísticos (se acontecer, registrar seed na mensagem do teste).
-
-# Estratégia de Testes
-
-## Escopo atual
-- **Gerador**: validação de schema v1.1 (`specs/schema_input.json` e `specs/schema_output.json`),
-  conectividade, densidade-alvo (tolerância), CV de velocidade (cap e warning), gate de modularidade.
-- **Sanidade**: execução “fim-a-fim” em cenários curtos com persistência `.json`/`.json.gz`.
-
-## Tipos de teste
-- **Unitários** (`tests/test_generator.py`): funções utilitárias (bisseção de ε, amostragem,
-  validações de campos), flags e caps.
-- **Integração** (`tests/test_sanity.py`): CLI e JSON-first, do input ao output.
-- **Regressão** (novos): “gate” de modularidade, CV perto do teto (cap), schema freeze.
-
-## Como rodar
 ```bash
-poetry run pytest -q
-````
+poetry run pytest -q -k "not (kahip or solvers_external)"
+```
 
-## Cobertura
+This command is equivalent to the final step in `.github/workflows/ci.yml`, with the difference
+that Poetry manages the environment instead of `pip install .` directly.
 
-* Alvo inicial: **75%** (subir gradualmente).
-* Métrica: `pytest-cov` com relatórios `term-missing` e `xml` (para CI).
+### 2.2. Quick smoke subset
 
-## Marcadores
+For a fast feedback loop, a smoke subset can be selected via pytest markers and/or file names.
+A typical pattern is:
 
-* `@pytest.mark.schema` — casos que validam contratos.
-* `@pytest.mark.cli` — execução via CLI.
-* `@pytest.mark.slow` — testes pesados (opt-out por padrão).
-* `@pytest.mark.docs` — exemplos do README/docs (evita bit rot).
+```bash
+# Example: smoke-only, if markers are available
+poetry run pytest -q -m smoke
 
-````
+# Or restrict to smoke-related files
+poetry run pytest -q tests/test_sanity.py tests/test_runner_smoke.py tests/test_solvers_smoke.py
+```
 
-`docs/testing/CI.md`
-```markdown
-# Integração Contínua (CI)
+The exact markers used may evolve over time; refer to test files and `pytest.ini` for the
+current configuration.
 
-## Pipeline
-1. **Instalação** via Poetry.
-2. **Linters** (ruff) e formatação (black --check).
-3. **Testes** com cobertura (pytest + pytest-cov).
-4. **Artefatos**: `coverage.xml` e `site/` (build do MkDocs).
-5. (Opcional) **Publicação** do site no GitHub Pages.
+### 2.3. Focusing on a single module or test
 
-## Branches/Disparos
-- `push`/`pull_request` para `main` e branches de release.
-- Jobs rodam em Python 3.11.
+Pytest allows selecting individual modules or tests for debugging:
 
-## Falhas comuns
-- Queda de cobertura abaixo do limiar.
-- `ruff`/`black` acusando style.
-- Docstrings ausentes em objetos expostos nas páginas de API.
+```bash
+# Single module
+poetry run pytest tests/test_generator.py
+
+# Single test function (example name)
+poetry run pytest tests/test_generator.py -k "test_n2000_panel_regime"
+```
+
+Replace `"test_n2000_panel_regime"` with the actual test name of interest.
+
+---
+
+## 3. Running tests like CI (without Poetry)
+
+The CI pipeline uses a **plain virtual environment** with `pip`:
+
+1. create and activate a venv;
+2. `pip install .` plus `pytest`;
+3. run the filtered suite.
+
+Equivalent steps locally:
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+
+python -m pip install --upgrade pip
+pip install -U pytest
+pip install .
+```
+
+Then:
+
+```bash
+pytest -q -k "not (kahip or solvers_external)"
+```
+
+This matches the `Install Python deps (pip only)` and `Run tests` steps in the CI workflow.
+
+---
+
+## 4. External solvers (METIS / KaHIP)
+
+Some tests depend on external solvers:
+
+* **METIS** via `gpmetis` (installed from the `metis` package on Ubuntu);
+* **KaHIP** via `kaffpa` (built and installed separately).
+
+The CI workflow always installs `metis`:
+
+```bash
+sudo apt-get install -y metis
+gpmetis -h | head -n1 || true
+```
+
+KaHIP is currently optional in the minimal CI job, but is required for the **full experimental
+baseline**. Tests that depend on KaHIP are either:
+
+* marked so they can be skipped when `kaffpa` is missing, or
+* excluded by the `-k "not (kahip or solvers_external)"` expression.
+
+To run **all** solver tests locally, once both solvers are installed and on `PATH`:
+
+```bash
+poetry run pytest tests/test_solvers_smoke.py tests/test_solvers_external.py
+```
+
+---
+
+## 5. Schema and instance sanity tests
+
+The suite includes tests that validate:
+
+* result JSONs against the schema in
+  `specs/jsonschema/solver_run.schema.v1.json` (`tests/test_results_schema.py`);
+* instance JSONs against the input schema in `specs/schema_input.json`
+  (`tests/test_instances_sanity.py`);
+* properties of the synthetic panel, such as:
+
+  * degree / “speed” coefficient-of-variation bands (`tests/test_degree_cv_bands.py`);
+  * CV ceilings and other constraints (`tests/test_degree_cv_cap.py`);
+  * modularity gates and related thresholds (`tests/test_modularity_gate_regression.py`).
+
+These tests act as a safety net when changing:
+
+* the instance generator;
+* the definitions of regimes in `configs/instances_to_generate.yaml`;
+* the experiment plans in `configs/plan_phase_1*.yaml`.
+
+If any of these tests fail, the new code or configuration should be considered incompatible with
+the existing experimental protocol until investigated.
+
+---
+
+## 6. Pre-commit integration
+
+The repository ships with a `.pre-commit-config.yaml` that includes, among other checks:
+
+* trailing whitespace and end-of-file (EOF) fixes;
+* YAML / JSON validation;
+* code formatting (Black);
+* linting (Ruff);
+* type checking (Mypy);
+* a smoke subset of tests (via pytest).
+
+After installing development dependencies with Poetry, you can enable pre-commit hooks with:
+
+```bash
+poetry run pre-commit install -f
+```
+
+Then, to run all hooks on the current tree:
+
+```bash
+poetry run pre-commit run -a
+```
+
+Pre-commit is not required to run the test suite, but it helps enforce consistent style and
+basic correctness before opening a pull request.
+
+```
+```

--- a/docs/testing/TRACEABILITY.md
+++ b/docs/testing/TRACEABILITY.md
@@ -1,10 +1,194 @@
-# Rastreabilidade Teste ↔ Requisito
+# Testing traceability
 
-| Requisito / Decisão | Teste(s) | Evidência / Saída |
-|---|---|---|
-| Schema de entrada/saída v1.1 | `tests/test_generator.py::test_schema_output_v11` | `data/results_raw/*.json` compatíveis |
-| Conectividade e densidade | `tests/test_generator.py::test_density_bisection` | `density_final` dentro de `δ_p` |
-| Gate de modularidade (dinâmico) | `tests/test_generator.py::test_modularity_gate_regression` | `modularity is None` quando m > limite |
-| Cap de CV (≤ 1/3) | `tests/test_generator.py::test_cv_capping` | warning + `cv_final≈1/3±0.02` |
-| CLI JSON-first e compressão `.gz` | `tests/test_sanity.py::test_cli_json_gz` | arquivos `.json`/`.json.gz` válidos |
-| Freeze do schema | `tests/test_generator.py::test_schema_freeze` | versão esperada carregada |
+This document provides a high-level view of how quality requirements, specifications and tests
+are connected in the FORJA / HPC Framework project.
+
+The goal is to make it clear **which artefacts support which claims** in the thesis and in the
+repository documentation.
+
+---
+
+## 1. Artefact map
+
+Key artefacts involved in testing and traceability:
+
+- **Specifications and bounds**
+  - `specs/bounds.json`
+  - `specs/schema_input.json`
+  - `specs/jsonschema/solver_run.schema.v1.json`
+- **Configuration and contracts**
+  - experiment plans in `configs/*.yaml` (e.g. `configs/plan_phase_1.yaml`);
+  - instance-generation regimes in `configs/instances_to_generate.yaml`.
+- **Code and modules**
+  - core logic under `src/gpp_core/`, `src/heuristics/`, `src/hpc_framework/`, `src/generator/`.
+- **Tests**
+  - test modules under `tests/` (unit, regression, schema, smoke);
+  - manual test-case descriptions under `docs/testing/testcases/TC_*.md`.
+- **CI and QA**
+  - GitHub Actions workflow: `.github/workflows/ci.yml`;
+  - pre-commit configuration: `.pre-commit-config.yaml`.
+
+---
+
+## 2. From requirements to tests
+
+The table below sketches the relationship between **requirements**, **specifications** and
+**tests**. It is not exhaustive, but covers the most critical aspects.
+
+### 2.1. Integrity of synthetic instances (LFS + gzip)
+
+- **Requirement**
+  Synthetic instances under `data/instances/synthetic/` must be valid gzip-compressed JSON
+  payloads, not Git LFS pointers.
+
+- **Implementation / spec**
+  - instances tracked with Git LFS when appropriate;
+  - filenames reflecting regimes (e.g. `n2000_p50.json.gz`).
+
+- **Tests & checks**
+  - CI step “Ensure Git LFS & materialize blobs” in `.github/workflows/ci.yml`;
+  - CI step “GZIP sanity” (uses `gzip -t`) in the same workflow.
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_005_perf_smoke.md` (includes integrity checks as part of smoke).
+
+---
+
+### 2.2. Instance schema and structural sanity
+
+- **Requirement**
+  All instance JSONs must conform to `specs/schema_input.json` and basic structural invariants.
+
+- **Implementation / spec**
+  - `specs/schema_input.json` (canonical input schema);
+  - regimes defined in `configs/instances_to_generate.yaml`.
+
+- **Tests**
+  - `tests/test_instances_sanity.py` (general structural checks);
+  - `tests/test_generator.py` (integration with the generator).
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_002_cv_ceiling.md` (regime constraints);
+  - `docs/testing/testcases/TC_001_modularity_gate.md` (additional structural gates via modularity).
+
+---
+
+### 2.3. Degree / “speed” heterogeneity (CV bands and ceilings)
+
+- **Requirement**
+  Synthetic instances must obey coefficient-of-variation (CV) bands and ceilings defined in
+  the experimental design.
+
+- **Implementation / spec**
+  - CV-related bounds in `specs/bounds.json` (where applicable);
+  - regimes in `configs/instances_to_generate.yaml`.
+
+- **Tests**
+  - `tests/test_degree_cv_bands.py` (CV bands);
+  - `tests/test_degree_cv_cap.py` (CV ceilings).
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_002_cv_ceiling.md`.
+
+---
+
+### 2.4. Modularity gate and regime classification
+
+- **Requirement**
+  Certain experiments rely on distinguishing instances by community structure / modularity.
+  Changes to the generator or bounds must not break this classification.
+
+- **Implementation / spec**
+  - modularity-related thresholds in `specs/bounds.json` or related configuration files.
+
+- **Tests**
+  - `tests/test_modularity_gate_regression.py`.
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_001_modularity_gate.md`.
+
+---
+
+### 2.5. Result schema and manifest contracts
+
+- **Requirement**
+  Solver outputs and manifests must conform to `specs/jsonschema/solver_run.schema.v1.json`,
+  enabling consistent aggregation and external analysis.
+
+- **Implementation / spec**
+  - `specs/jsonschema/solver_run.schema.v1.json` (canonical result schema);
+  - scripts:
+    - `scripts/pack_manifest_v1.py`
+    - `scripts/validate_manifest_v1.py`
+    - `scripts/aggregate_manifests.py`.
+
+- **Tests**
+  - `tests/test_results_schema.py` (schema-level validation);
+  - integration tests around manifest generation.
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_003_schema_freeze.md`.
+
+---
+
+### 2.6. CLI contracts and examples
+
+- **Requirement**
+  Command-line interfaces (CLIs) for the generator and runner must behave consistently with the
+  documented examples and plans.
+
+- **Implementation / spec**
+  - CLI modules:
+    - `src/generator/cli.py`
+    - `src/hpc_framework/cli.py`
+  - experiment plans under `configs/`.
+
+- **Tests**
+  - `tests/test_entrypoints.py` (exposing and validating public entry points);
+  - `tests/test_public_api.py` (public-facing API stability).
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_004_cli_examples.md`.
+
+---
+
+### 2.7. Performance and smoke behaviour
+
+- **Requirement**
+  A minimal subset of tests must run quickly and reliably to support pre-commit hooks and CI
+  smoke checks.
+
+- **Implementation / spec**
+  - `.pre-commit-config.yaml` (smoke pytest hook);
+  - CI workflow (`.github/workflows/ci.yml`) with filtered pytest invocation.
+
+- **Tests**
+  - `tests/test_sanity.py`;
+  - `tests/test_runner_smoke.py`;
+  - `tests/test_solvers_smoke.py`.
+
+- **Test case doc**
+  - `docs/testing/testcases/TC_005_perf_smoke.md`.
+
+---
+
+## 3. Maintaining traceability
+
+When changing any of the following:
+
+- schemas under `specs/`;
+- experiment plans under `configs/`;
+- generator logic (`src/generator/`);
+- CLI behaviour (`src/hpc_framework/cli.py`, `src/generator/cli.py`);
+- CI configuration (`.github/workflows/ci.yml`),
+
+developers should:
+
+1. Identify which tests and `TC_00X` documents are affected.
+2. Update tests and documentation together, keeping the mapping in this file accurate.
+3. Run at least:
+   - the full pytest suite locally (preferably via Poetry);
+   - `poetry run pre-commit run -a` for style and basic QA.
+
+This ensures that claims made in the thesis and in the documentation remain backed by executable
+tests and verifiable artefacts.

--- a/docs/testing/testcases/TC_001_modularity_gate.md
+++ b/docs/testing/testcases/TC_001_modularity_gate.md
@@ -1,24 +1,78 @@
-# TC_001 — Regressão do Gate de Modularidade
+````markdown
+# TC_001 – Modularity gate regression
 
-**Objetivo**
-Garantir que, quando o grafo ultrapassa o **limite dinâmico de modularidade** (definido e documentado no código/CHANGELOG), o campo `instance_metrics.modularity` seja **`null`** no JSON gerado.
+**ID:** TC_001
+**Title:** Modularity gate regression
+**Type:** Regression / regime validation
 
-**Pré-condições**
-- Python 3.11
-- CLI do gerador instalado (`poetry run <cli>` ou entry-point equivalente)
-- `jsonschema` disponível
-- Semente fixa no teste
+---
 
-**Passos (Given–When–Then)**
-1. *Given* um cenário “denso” (ex.: `n≈3000`, `p≈0.50`) com parâmetros do gerador que acionem o limite.
-2. *When* o CLI é executado gerando um arquivo `*.json.gz` em `tmp_path`.
-3. *Then* o JSON parseado apresenta `instance_metrics.modularity == null`.
-4. (Opcional) *And* os logs contêm menção ao gate.
+## 1. Purpose
 
-**Resultados esperados**
-- `modularity` presente e `null`.
-- JSON válido no `schema_input.json` (v1.1).
+Ensure that changes to the instance generator, bounds or configuration do **not** break the
+modularity-based gate used to classify or filter instances by community structure.
 
-**Notas**
-- Não validar fórmula específica do limite aqui — apenas o **efeito** (pular modularidade).
-- Seeds fixas para reduzir variação.
+This test case is linked to the regression test in `tests/test_modularity_gate_regression.py`.
+
+---
+
+## 2. Preconditions
+
+- The project is installed (via Poetry or a plain virtualenv).
+- Synthetic instances have been generated according to `configs/instances_to_generate.yaml`.
+- Python tests can be executed (see `docs/testing/TESTING.md`).
+
+---
+
+## 3. Procedure
+
+1. Ensure the development environment is set up (Poetry recommended):
+
+   ```bash
+   cd ~/MPP
+   poetry install --with dev -E metrics
+````
+
+2. Run the modularity gate regression test:
+
+   ```bash
+   poetry run pytest tests/test_modularity_gate_regression.py
+   ```
+
+3. Observe the output, paying attention to:
+
+   * any failures related to modularity thresholds or regime classification;
+   * any new warnings that indicate borderline cases.
+
+---
+
+## 4. Expected results
+
+* All tests in `test_modularity_gate_regression.py` **pass**.
+* Reported modularity values stay within the expected ranges encoded in the test and in
+  the supporting specifications (e.g. `specs/bounds.json`).
+
+If a failure occurs, the change that triggered it (in the generator, bounds or configuration)
+must be reviewed. The test expectations should only be updated when there is a deliberate and
+documented change to the experimental design.
+
+---
+
+## 5. Related artefacts
+
+* **Code / tests**
+
+  * `tests/test_modularity_gate_regression.py`
+
+* **Specs / configuration**
+
+  * `specs/bounds.json` (where applicable)
+  * `configs/instances_to_generate.yaml`
+
+* **Documentation**
+
+  * `docs/reports/01_instance_generator.md`
+  * `docs/testing/TRACEABILITY.md` (section on modularity gate)
+
+```
+```

--- a/docs/testing/testcases/TC_002_cv_ceiling.md
+++ b/docs/testing/testcases/TC_002_cv_ceiling.md
@@ -1,25 +1,84 @@
-# TC_002 — Teto de CV (1/3) e Warnings
+````markdown
+# TC_002 – Degree / “speed” CV bands and ceilings
 
-**Objetivo**
-Validar a política de **cap de CV = 1/3** (média central) e emissão de *warning* quando a meta solicitada excede o teto.
+**ID:** TC_002
+**Title:** Degree / “speed” coefficient-of-variation constraints
+**Type:** Regime validation
 
-**Pré-condições**
-- Python 3.11, CLI disponível
-- Geração de atributo "velocidade" ativa
+---
 
-**Entradas (parametrizadas)**
-- `cv_target ∈ {0.29, 0.33, 0.40}`
+## 1. Purpose
 
-**Passos**
-Para cada `cv_target`:
-1. Executar o gerador produzindo o JSON.
-2. Ler `instance_metrics.cv_vel_final` (ou campo equivalente).
-3. Capturar logs/STDERR para warnings (quando capado).
+Verify that synthetic instances obey the **coefficient-of-variation (CV) bands and ceilings**
+defined in the experimental design for degree or “speed” distributions.
 
-**Resultados esperados**
-- `0.29`: **sem warning**; erro relativo `|cv_final - 0.29| ≤ 0.02`.
-- `0.33`: comportamento limite; pode existir *warning* informativo (aceitável).
-- `0.40`: **warning de cap**; `cv_final ≈ 1/3 ± 0.02`.
+This test case is linked to `tests/test_degree_cv_bands.py` and `tests/test_degree_cv_cap.py`.
 
-**Notas**
-- Documentado também no `README` (“Limites do CV”) e no `CHANGELOG`.
+---
+
+## 2. Preconditions
+
+- The project is installed and tests are runnable (via Poetry or a plain virtualenv).
+- Synthetic instances have been generated according to `configs/instances_to_generate.yaml`.
+- Bounds for CV bands / ceilings are defined in the appropriate specification files
+  (e.g. `specs/bounds.json`).
+
+---
+
+## 3. Procedure
+
+1. Ensure the development environment is set up:
+
+   ```bash
+   cd ~/MPP
+   poetry install --with dev -E metrics
+````
+
+2. Run the CV-related tests:
+
+   ```bash
+   poetry run pytest tests/test_degree_cv_bands.py tests/test_degree_cv_cap.py
+   ```
+
+3. Inspect any failures or warnings, focusing on:
+
+   * instances whose CV falls outside the intended bands;
+   * violations of CV ceilings for specific regimes.
+
+---
+
+## 4. Expected results
+
+* All tests in `test_degree_cv_bands.py` and `test_degree_cv_cap.py` **pass**.
+* Reported CV values adhere to the bands and ceilings encoded in the tests and in the configuration.
+
+If failures occur, investigate whether they are due to:
+
+* changes in the generator algorithm;
+* changes in `configs/instances_to_generate.yaml`;
+* inconsistent bounds in `specs/bounds.json`.
+
+Only adjust test expectations when there is a deliberate and documented change in the experimental
+regimes.
+
+---
+
+## 5. Related artefacts
+
+* **Code / tests**
+
+  * `tests/test_degree_cv_bands.py`
+  * `tests/test_degree_cv_cap.py`
+
+* **Specs / configuration**
+
+  * `specs/bounds.json`
+  * `configs/instances_to_generate.yaml`
+
+* **Documentation**
+
+  * `docs/reports/01_instance_generator.md`
+  * `docs/testing/TRACEABILITY.md` (CV-related section)
+
+```
+```

--- a/docs/testing/testcases/TC_003_schema_freeze.md
+++ b/docs/testing/testcases/TC_003_schema_freeze.md
@@ -1,20 +1,99 @@
-# TC_003 — Congelamento do Schema v1.1
+````markdown
+# TC_003 – Result schema freeze (`solver_run.schema.v1.json`)
 
-**Objetivo**
-Assegurar que os JSONs produzidos seguem o **schema v1.1** (inputs e/ou outputs), incluindo a aceitação explícita de `modularity: null`.
+**ID:** TC_003
+**Title:** Result schema freeze for solver manifests
+**Type:** Contract / integration
 
-**Pré-condições**
-- `jsonschema` instalado
-- Schema carregado de `specs/schema_input.json` (ou de uma pasta versionada `specs/1.1/...` quando congelar)
+---
 
-**Passos**
-1. Carregar o schema **exato** que o projeto declara como oficial (v1.1).
-2. Validar o JSON gerado pelo CLI para um cenário básico.
-3. Injetar `modularity: null` e validar novamente.
+## 1. Purpose
 
-**Resultados esperados**
-- Validação **aprovada** com `modularity: null`.
-- Validação **aprovada** para campos obrigatórios mínimos documentados.
+Ensure that solver result manifests (`*.v1.json`) conform to the **frozen JSON schema**
+`solver_run.schema.v1.json`, and that changes to this schema or to the manifest structure
+are deliberate and traceable.
 
-**Notas**
-- Quando o schema for versionado em pastas (ex.: `specs/1.1/…`), atualizar o *loader* e este teste.
+This test case is linked to `tests/test_results_schema.py` and to the helper scripts used
+in the Phase 1 campaign.
+
+---
+
+## 2. Preconditions
+
+- The project is installed and tests are runnable (via Poetry or a plain virtualenv).
+- Some result manifests exist, for example:
+  - `data/results_raw/smoke_metis.v1.json`
+  - `data/results_raw/phase1/out_metis.v1.json`
+  - `data/results_raw/phase1/out_kahip.v1.json`
+- The schema file is present:
+
+  ```text
+  specs/jsonschema/solver_run.schema.v1.json
+````
+
+---
+
+## 3. Procedure
+
+1. Ensure the development environment is set up:
+
+   ```bash
+   cd ~/MPP
+   poetry install --with dev -E metrics
+   ```
+
+2. Run the schema tests:
+
+   ```bash
+   poetry run pytest tests/test_results_schema.py
+   ```
+
+3. Optionally, validate specific manifests via the helper script:
+
+   ```bash
+   poetry run python scripts/validate_manifest_v1.py \
+     --schema specs/jsonschema/solver_run.schema.v1.json \
+     --in data/results_raw/smoke_metis.v1.json \
+         data/results_raw/phase1/out_metis.v1.json \
+         data/results_raw/phase1/out_kahip.v1.json
+   ```
+
+4. Inspect any failures, focusing on:
+
+   * missing or renamed fields;
+   * type mismatches;
+   * structural changes (e.g., different nesting).
+
+---
+
+## 4. Expected results
+
+* All tests in `test_results_schema.py` **pass**.
+* `validate_manifest_v1.py` reports `[OK]` for all selected manifests.
+* Any change to `solver_run.schema.v1.json` or to the manifest shape is:
+
+  * reflected in tests;
+  * documented in the specification and in the repository changelog.
+
+---
+
+## 5. Related artefacts
+
+* **Code / tests**
+
+  * `tests/test_results_schema.py`
+  * `scripts/pack_manifest_v1.py`
+  * `scripts/validate_manifest_v1.py`
+  * `scripts/aggregate_manifests.py`
+
+* **Specs**
+
+  * `specs/jsonschema/solver_run.schema.v1.json`
+
+* **Documentation**
+
+  * `docs/reports/02_experimental_campaign.md`
+  * `docs/testing/TRACEABILITY.md` (result schema section)
+
+```
+```

--- a/docs/testing/testcases/TC_004_cli_examples.md
+++ b/docs/testing/testcases/TC_004_cli_examples.md
@@ -1,21 +1,101 @@
-# TC_004 — Exemplos do README (Smoke CLI)
+````markdown
+# TC_004 – CLI examples and contracts
 
-**Objetivo**
-Verificar que os **exemplos do README** executam e produzem artefatos no local esperado.
+**ID:** TC_004
+**Title:** CLI examples and contracts (generator and runner)
+**Type:** Usability / integration
 
-**Pré-condições**
-- CLI disponível
-- `README.md` atualizado com pelo menos 2 exemplos reais
+---
 
-**Passos**
-1. Rodar os comandos de exemplo em `tmp_path`.
-2. Verificar a existência dos arquivos (`*.json` ou `*.json.gz`).
-3. (Opcional) Abrir e checar 1–2 campos chave.
+## 1. Purpose
 
-**Resultados esperados**
-- Comandos executam sem erro.
-- Artefatos existem no caminho indicado.
-- JSON parseável.
+Verify that the documented CLI examples for:
 
-**Notas**
-- Sinalizar no README que `--verbose` pode reduzir throughput (não usar nos exemplos, salvo justificativa).
+- the **instance generator** (`generator.cli`), and
+- the **experiment runner** (`hpc_framework.cli`)
+
+remain valid and behave as described in the documentation.
+
+---
+
+## 2. Preconditions
+
+- The project is installed (via Poetry or an equivalent virtual environment).
+- External solvers (METIS, KaHIP) are installed and on `PATH` if full experiments are to be run.
+- The documentation pages are up to date:
+  - `docs/api/generator_cli.md`
+  - `docs/api/hpc_framework_cli.md`
+  - `docs/reports/02_experimental_campaign.md`
+
+---
+
+## 3. Procedure
+
+1. Inspect the current CLI help for the generator:
+
+   ```bash
+   cd ~/MPP
+   poetry run python -m generator.cli --help
+````
+
+Compare the available subcommands and options with the description in
+`docs/api/generator_cli.md`.
+
+2. Inspect the current CLI help for the runner:
+
+   ```bash
+   poetry run python -m hpc_framework.cli --help
+   ```
+
+   Compare the output against `docs/api/hpc_framework_cli.md`.
+
+3. Execute the Phase 1 plan using the documented command:
+
+   ```bash
+   ./scripts/run_phase_1.sh
+   ```
+
+   Confirm that:
+
+   * the output paths match the description in
+     `docs/reports/02_experimental_campaign.md`;
+   * raw JSON files under `data/results_raw/phase1/` are generated as expected.
+
+4. If relevant, test a minimal generator invocation (single instance), following the
+   high-level pattern in `docs/api/generator_cli.md`, and verify that the output file
+   adheres to `specs/schema_input.json`.
+
+---
+
+## 4. Expected results
+
+* CLI help output for both modules is consistent with the documentation.
+* The Phase 1 plan runs successfully and writes results to the locations documented
+  in `02_experimental_campaign.md`.
+* Any discrepancies (missing flags, renamed commands, changed defaults) are either:
+
+  * corrected in the code to restore the documented behaviour, or
+  * documented explicitly and propagated to the relevant pages.
+
+---
+
+## 5. Related artefacts
+
+* **Code**
+
+  * `src/generator/cli.py`
+  * `src/hpc_framework/cli.py`
+
+* **Docs**
+
+  * `docs/api/generator_cli.md`
+  * `docs/api/hpc_framework_cli.md`
+  * `docs/reports/02_experimental_campaign.md`
+
+* **Specs**
+
+  * `specs/schema_input.json`
+  * `configs/plan_phase_1.yaml`
+
+```
+```

--- a/docs/testing/testcases/TC_005_perf_smoke.md
+++ b/docs/testing/testcases/TC_005_perf_smoke.md
@@ -1,18 +1,102 @@
-# TC_005 — Smoke de Desempenho (Opcional)
+````markdown
+# TC_005 – Smoke and performance sanity
 
-**Objetivo**
-Capturar **regressões grosseiras** de tempo e memória sem quebrar a CI.
+**ID:** TC_005
+**Title:** Smoke and performance sanity
+**Type:** Smoke / performance
 
-**Pré-condições**
-- Ambiente estável o suficiente para comparação aproximada.
+---
 
-**Passos**
-1. Rodar um cenário leve (ex.: `n≈2000`, `p≈0.40`).
-2. Medir tempo de parede simples (Python) e, se viável, RSS.
-3. Comparar com baseline guardado em comentários ou arquivo leve.
+## 1. Purpose
 
-**Critério**
-- Se `tempo_atual > 2 × baseline`: marcar `xfail` com mensagem e **NÃO** falhar a pipeline.
+Ensure that a **minimal, fast subset** of tests can be run:
 
-**Notas**
-- O baseline deve ser tomado em máquina similar (documente em `BENCH.md`).
+- locally (for quick developer feedback),
+- via pre-commit hooks,
+- and in CI,
+
+without depending on heavy external solvers or long-running experiments.
+
+This test case is associated with the smoke-related tests and with the CI configuration.
+
+---
+
+## 2. Preconditions
+
+- The project is installed (via Poetry or a plain virtualenv).
+- External solvers are optional for this test case; the smoke subset must not require KaHIP.
+
+---
+
+## 3. Procedure
+
+1. Run the smoke subset locally via pytest (example patterns):
+
+   ```bash
+   cd ~/MPP
+   poetry install --with dev -E metrics
+
+   # Marker-based smoke (if configured)
+   poetry run pytest -q -m smoke
+
+   # Or file-based smoke
+   poetry run pytest -q tests/test_sanity.py tests/test_runner_smoke.py tests/test_solvers_smoke.py
+````
+
+2. Run the minimal CI-equivalent test selection:
+
+   ```bash
+   poetry run pytest -q -k "not (kahip or solvers_external)"
+   ```
+
+3. Optionally, test pre-commit integration:
+
+   ```bash
+   poetry run pre-commit run -a
+   ```
+
+   Verify that the pytest hook (if present) completes quickly.
+
+4. Observe total runtime and verify that it is suitable for frequent local runs and CI.
+
+---
+
+## 4. Expected results
+
+* Smoke-related tests (`test_sanity.py`, `test_runner_smoke.py`, `test_solvers_smoke.py`)
+  pass consistently.
+* The CI-equivalent selection (`-k "not (kahip or solvers_external)"`) completes within a
+  reasonable time on a typical development machine and in the GitHub-hosted runner.
+* Pre-commit hooks complete without unexpected timeouts.
+
+If any smoke test becomes too slow or flaky, it should be:
+
+* refactored or moved to a slower test group; and
+* documented accordingly in `docs/testing/TESTING.md` and this file.
+
+---
+
+## 5. Related artefacts
+
+* **Tests**
+
+  * `tests/test_sanity.py`
+  * `tests/test_runner_smoke.py`
+  * `tests/test_solvers_smoke.py`
+
+* **CI**
+
+  * `.github/workflows/ci.yml`
+
+* **Pre-commit**
+
+  * `.pre-commit-config.yaml`
+
+* **Docs**
+
+  * `docs/testing/TESTING.md`
+  * `docs/testing/CI.md`
+  * `docs/testing/TRACEABILITY.md`
+
+```
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: HPC Framework Docs
-site_url: https://gorgomel.github.io/Heuristic_Benchmarking_Framework/
-repo_url: https://github.com/Gorgomel/Heuristic_Benchmarking_Framework
+site_url: https://lbsl98.github.io/Heuristic_Benchmarking_Framework/
+repo_url: https://github.com/LBSL98/Heuristic_Benchmarking_Framework
 theme:
   name: material
 
@@ -8,18 +8,25 @@ nav:
   - Home: index.md
   - Protocol: protocol/proto_v3.1.1.md
   - API:
-    - Generator CLI: api/generator_cli.md
-    - Heuristics (Greedy): api/heuristics_greedy.md
-    - Framework CLI: api/hpc_framework_cli.md
-    - SSH Orchestrator: api/orchestrator_ssh_executor.md
+      - Generator CLI: api/generator_cli.md
+      - Heuristics (Greedy): api/heuristics_greedy.md
+      - SSH Orchestrator: api/orchestrator_ssh_executor.md
   - Reports:
-    - Instance Generator: reports/01_instance_generator.md
-    - Experimental Campaign: reports/02_experimental_campaign.md
+      - Instance Generator: reports/01_instance_generator.md
+  - Testing:
+      - CI: testing/CI.md
+      - Testing Guide: testing/TESTING.md
+      - Traceability: testing/TRACEABILITY.md
+      - Test Cases:
+          - TC_001 Modularity Gate: testing/testcases/TC_001_modularity_gate.md
+          - TC_002 CV Ceiling: testing/testcases/TC_002_cv_ceiling.md
+          - TC_003 Schema Freeze: testing/testcases/TC_003_schema_freeze.md
+          - TC_004 CLI Examples: testing/testcases/TC_004_cli_examples.md
+          - TC_005 Perf Smoke: testing/testcases/TC_005_perf_smoke.md
   - Decisions:
-    - 001 Language Choice: decisions/001_choice_heuristic_language.md
-    - 003 Methodology: decisions/003_metodologia_gerador_e_analise.md
-    - 004 Testing & CI: decisions/004_testing_and_ci.md
-
+      - 001 Language Choice: decisions/001_choice_heuristic_language.md
+      - 003 Methodology: decisions/003_metodologia_gerador_e_analise.md
+      - 004 Testing & CI: decisions/004_testing_and_ci.md
 
 plugins:
   - search


### PR DESCRIPTION
Resumo
- recupera a trilha documental mínima após o fechamento da PR anterior
- mantém apenas documentação do gerador, CI, testing, traceability e testcases
- inclui ajuste mínimo de navegação do MkDocs

Validação local
- mkdocs build --strict: passou

Observação
- esta PR continua restrita ao subconjunto documental defensável no estado atual do repositório
