### PR TITLE
feat: integrate greedy baseline into declarative plan flow

### DIFF
--- a/specs/jsonschema/solver_run.schema.v1.json
+++ b/specs/jsonschema/solver_run.schema.v1.json
@@ -22,7 +22,7 @@
   "properties": {
     "timestamp": { "type": "string", "format": "date-time" },
     "instance_id": { "type": "string" },
-    "algo": { "type": "string", "enum": ["metis", "kahip"] },
+    "algo": { "type": "string", "enum": ["metis", "kahip", "greedy"] },
     "k": { "type": "integer", "minimum": 2 },
     "beta": { "type": "number", "minimum": 0 },
     "seed": { "type": "integer", "minimum": 0 },

--- a/src/hpc_framework/greedy_adapter.py
+++ b/src/hpc_framework/greedy_adapter.py
@@ -1,0 +1,67 @@
+"""Adaptadores para integrar o baseline guloso ao fluxo declarativo do framework."""
+
+from __future__ import annotations
+
+import networkx as nx
+import numpy as np
+
+from heuristics.greedy import run_greedy_heuristic
+from hpc_framework.runner import compute_cutsize_edges_labels, extract_graph_from_instance
+
+
+def clusters_to_labels(clusters: list[set[int]], n: int) -> np.ndarray:
+    """Converte clusters (list[set[int]]) em vetor de rótulos zero-based."""
+    labels = np.full(n, -1, dtype=int)
+
+    for cluster_id, cluster in enumerate(clusters):
+        for v in cluster:
+            if labels[v] != -1:
+                raise ValueError("Some vertices were assigned more than once.")
+            labels[v] = cluster_id
+
+    if np.any(labels < 0):
+        raise ValueError("Some vertices were not assigned to any cluster.")
+
+    return labels
+
+
+def observed_k_from_labels(labels: np.ndarray) -> int:
+    """Retorna o número de blocos distintos observados em um vetor de rótulos."""
+    if labels.ndim != 1:
+        raise ValueError("labels must be a 1D array")
+    return int(np.unique(labels).size)
+
+
+def instance_to_nx_graph(inst: dict) -> nx.Graph:
+    """Converte uma instância JSON para networkx.Graph."""
+    g = nx.Graph()
+
+    for node in inst.get("nodes", []):
+        node_id = int(node["id"])
+        attrs = {k: v for k, v in node.items() if k != "id"}
+        g.add_node(node_id, **attrs)
+
+    for edge in inst.get("edges", []):
+        u, v = int(edge[0]), int(edge[1])
+        g.add_edge(u, v)
+
+    return g
+
+
+def run_greedy_adapter(inst: dict, delta_v: float) -> np.ndarray:
+    """Executa a heurística gulosa sobre a instância e devolve labels zero-based."""
+    graph = instance_to_nx_graph(inst)
+    clusters = run_greedy_heuristic(graph, delta_v=delta_v)
+    n = graph.number_of_nodes()
+    return clusters_to_labels(clusters, n=n)
+
+
+def run_greedy_observation(inst: dict, delta_v: float) -> dict:
+    """Produz a observação mínima auditável do baseline guloso."""
+    labels = run_greedy_adapter(inst, delta_v=delta_v)
+    _, edges = extract_graph_from_instance(inst)
+    return {
+        "labels": labels,
+        "observed_k": observed_k_from_labels(labels),
+        "cutsize_best": compute_cutsize_edges_labels(edges, labels),
+    }

--- a/src/hpc_framework/plan_runner.py
+++ b/src/hpc_framework/plan_runner.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import gzip
+import json
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
-from .runner import run_one
+from .greedy_adapter import run_greedy_observation
+from .runner import _env_snapshot, _tool_version, _which, run_one
 
 SUPPORTED_SOLVERS = ("metis", "kahip")
 
@@ -16,12 +21,14 @@ def _load_plan(plan_path: Path) -> dict:
         return yaml.safe_load(f) or {}
 
 
+def _greedy_enabled(plan: dict) -> bool:
+    solvers = plan.get("solvers", {}) or {}
+    greedy_cfg = solvers.get("greedy", {}) or {}
+    return bool(greedy_cfg.get("enabled", False))
+
+
 def _enabled_supported_solvers(plan: dict) -> list[str]:
     solvers = plan.get("solvers", {}) or {}
-
-    greedy_cfg = solvers.get("greedy", {}) or {}
-    if bool(greedy_cfg.get("enabled", False)):
-        raise NotImplementedError("greedy is enabled in the plan, but no adapter exists yet")
 
     enabled: list[str] = []
     for name in SUPPORTED_SOLVERS:
@@ -63,8 +70,33 @@ def _solver_budget_time_ms(plan: dict, solver: str) -> int:
     return int(float(seconds) * 1000)
 
 
+def _greedy_budget_time_ms(plan: dict) -> int:
+    cfg = (plan.get("solvers", {}) or {}).get("greedy", {}) or {}
+    budget = cfg.get("budget", {}) or {}
+    seconds = budget.get("seconds", 1)
+    return int(float(seconds) * 1000)
+
+
 def _planned_runs(plan: dict) -> list[dict]:
     runs: list[dict] = []
+
+    if _greedy_enabled(plan):
+        greedy_cfg = (plan.get("solvers", {}) or {}).get("greedy", {}) or {}
+        greedy_params = greedy_cfg.get("params", {}) or {}
+        delta_v = float(greedy_params.get("delta_v", 0.1))
+
+        for instance in _included_instances(plan):
+            for seed in _rng_seeds(plan):
+                runs.append(
+                    {
+                        "instance": instance,
+                        "solver": "greedy",
+                        "seed": seed,
+                        "delta_v": delta_v,
+                        "budget_time_ms": _greedy_budget_time_ms(plan),
+                    }
+                )
+
     for instance in _included_instances(plan):
         for solver in _enabled_supported_solvers(plan):
             for seed in _rng_seeds(plan):
@@ -79,6 +111,84 @@ def _planned_runs(plan: dict) -> list[dict]:
                     }
                 )
     return runs
+
+
+def _read_instance_json(path: Path) -> dict[str, Any]:
+    if str(path).endswith(".gz"):
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            return json.load(f)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _greedy_tools_snapshot() -> dict:
+    return {
+        "gpmetis": {
+            "exists": bool(_which("gpmetis")),
+            "version": _tool_version(["gpmetis"]) if _which("gpmetis") else "",
+        },
+        "kaffpa": {
+            "exists": bool(_which("kaffpa")),
+            "version": _tool_version(["kaffpa"]) if _which("kaffpa") else "",
+        },
+    }
+
+
+def _write_greedy_result(
+    *,
+    raw_dir: Path,
+    instance_name: str,
+    instance_id: str,
+    seed: int,
+    delta_v: float,
+    budget_time_ms: int,
+    obs: dict,
+) -> None:
+    out_json = raw_dir / f"{Path(instance_name).name}__greedy__seed{seed}.json"
+
+    labels = obs["labels"]
+    labels_json = labels.tolist() if hasattr(labels, "tolist") else list(labels)
+
+    payload = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "instance_id": instance_id,
+        "algo": "greedy",
+        "k": int(obs["observed_k"]),
+        "beta": float(delta_v),
+        "seed": int(seed),
+        "budget_time_ms": int(budget_time_ms),
+        "status": "ok",
+        "returncode": 0,
+        "elapsed_ms": 0,
+        "stdout": "",
+        "stderr": "",
+        "metrics": {
+            "cutsize_best": int(obs["cutsize_best"]),
+            "n_nodes": len(labels_json),
+            "balance_tolerance": float(delta_v),
+            "imbalance_raw": None,
+        },
+        "env": _env_snapshot(),
+        "tools": _greedy_tools_snapshot(),
+        "paths": {
+            "workdir": "",
+            "graph_path": "",
+            "part_path": None,
+        },
+        "checkpoints": [
+            {
+                "time_ms": 0,
+                "cutsize_best": int(obs["cutsize_best"]),
+                "nfe": None,
+            }
+        ],
+        "schema_version": "1.0.0",
+        "schema_path": "specs/jsonschema/solver_run.schema.v1.json",
+        # compat legado
+        "cutsize_best": int(obs["cutsize_best"]),
+        "observed_k": int(obs["observed_k"]),
+        "labels": labels_json,
+    }
+    out_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def run_plan(plan_path: Path) -> None:
@@ -98,6 +208,20 @@ def run_plan(plan_path: Path) -> None:
 
     for run in runs:
         instance_path = base_dir / run["instance"]
+
+        if run["solver"] == "greedy":
+            inst = _read_instance_json(instance_path)
+            obs = run_greedy_observation(inst, delta_v=float(run["delta_v"]))
+            _write_greedy_result(
+                raw_dir=raw_dir,
+                instance_name=run["instance"],
+                instance_id=str(inst.get("instance_id", Path(run["instance"]).stem)),
+                seed=int(run["seed"]),
+                delta_v=float(run["delta_v"]),
+                budget_time_ms=int(run["budget_time_ms"]),
+                obs=obs,
+            )
+            continue
 
         stem = Path(run["instance"]).name
         out_json = raw_dir / f"{stem}__{run['solver']}__seed{run['seed']}.json"

--- a/tests/test_greedy_adapter.py
+++ b/tests/test_greedy_adapter.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from hpc_framework.greedy_adapter import clusters_to_labels, observed_k_from_labels
+
+
+def test_clusters_to_labels_builds_zero_based_partition_vector():
+    clusters = [{0, 2}, {1, 3, 4}]
+    labels = clusters_to_labels(clusters, n=5)
+
+    assert isinstance(labels, np.ndarray)
+    assert labels.shape == (5,)
+    assert labels.dtype.kind in {"i", "u"}
+
+    assert labels[0] == 0
+    assert labels[2] == 0
+    assert labels[1] == 1
+    assert labels[3] == 1
+    assert labels[4] == 1
+
+
+def test_clusters_to_labels_raises_if_some_vertex_is_unassigned():
+    clusters = [{0, 2}, {1}]
+    with pytest.raises(ValueError, match="not assigned"):
+        clusters_to_labels(clusters, n=4)
+
+
+def test_clusters_to_labels_raises_if_vertex_appears_twice():
+    clusters = [{0, 2}, {2, 3}]
+    with pytest.raises(ValueError, match="assigned more than once"):
+        clusters_to_labels(clusters, n=4)
+
+
+def test_observed_k_from_labels_counts_distinct_zero_based_blocks():
+    labels = np.array([0, 0, 1, 2, 2], dtype=int)
+    assert observed_k_from_labels(labels) == 3

--- a/tests/test_greedy_adapter_graph.py
+++ b/tests/test_greedy_adapter_graph.py
@@ -1,0 +1,31 @@
+import networkx as nx
+
+from hpc_framework.greedy_adapter import instance_to_nx_graph
+
+
+def test_instance_to_nx_graph_builds_graph_with_velocity_attributes():
+    inst = {
+        "instance_id": "toy",
+        "nodes": [
+            {"id": 0, "velocity": 1.5},
+            {"id": 1, "velocity": 2.0},
+            {"id": 2, "velocity": 2.5},
+        ],
+        "edges": [
+            [0, 1],
+            [1, 2],
+        ],
+    }
+
+    g = instance_to_nx_graph(inst)
+
+    assert isinstance(g, nx.Graph)
+    assert g.number_of_nodes() == 3
+    assert g.number_of_edges() == 2
+
+    assert g.has_edge(0, 1)
+    assert g.has_edge(1, 2)
+
+    assert g.nodes[0]["velocity"] == 1.5
+    assert g.nodes[1]["velocity"] == 2.0
+    assert g.nodes[2]["velocity"] == 2.5

--- a/tests/test_greedy_adapter_observation.py
+++ b/tests/test_greedy_adapter_observation.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from hpc_framework.greedy_adapter import run_greedy_observation
+
+
+def test_run_greedy_observation_returns_labels_observed_k_and_cutsize(monkeypatch):
+    def fake_run_greedy_adapter(inst, delta_v):
+        assert delta_v == 0.25
+        return np.array([0, 1, 0, 1], dtype=int)
+
+    import hpc_framework.greedy_adapter as adapter_mod
+
+    monkeypatch.setattr(adapter_mod, "run_greedy_adapter", fake_run_greedy_adapter, raising=False)
+
+    inst = {
+        "instance_id": "toy",
+        "num_nodes": 4,
+        "edges": [
+            [0, 1],
+            [1, 2],
+            [2, 3],
+        ],
+    }
+
+    obs = run_greedy_observation(inst, delta_v=0.25)
+
+    assert isinstance(obs, dict)
+    assert obs["labels"].tolist() == [0, 1, 0, 1]
+    assert obs["observed_k"] == 2
+    assert obs["cutsize_best"] == 3

--- a/tests/test_greedy_adapter_pipeline.py
+++ b/tests/test_greedy_adapter_pipeline.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from hpc_framework.greedy_adapter import run_greedy_adapter
+
+
+def test_run_greedy_adapter_converts_instance_and_clusters_to_labels(monkeypatch):
+    calls = {}
+
+    def fake_run_greedy_heuristic(graph, delta_v):
+        calls["n_nodes"] = graph.number_of_nodes()
+        calls["n_edges"] = graph.number_of_edges()
+        calls["delta_v"] = delta_v
+        return [{0, 2}, {1, 3}]
+
+    import hpc_framework.greedy_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod, "run_greedy_heuristic", fake_run_greedy_heuristic, raising=False
+    )
+
+    inst = {
+        "instance_id": "toy",
+        "nodes": [
+            {"id": 0, "velocity": 1.0},
+            {"id": 1, "velocity": 1.1},
+            {"id": 2, "velocity": 1.2},
+            {"id": 3, "velocity": 1.3},
+        ],
+        "edges": [
+            [0, 1],
+            [1, 2],
+            [2, 3],
+        ],
+    }
+
+    labels = run_greedy_adapter(inst, delta_v=0.25)
+
+    assert isinstance(labels, np.ndarray)
+    assert labels.tolist() == [0, 1, 0, 1]
+
+    assert calls["n_nodes"] == 4
+    assert calls["n_edges"] == 3
+    assert calls["delta_v"] == 0.25

--- a/tests/test_plan_runner.py
+++ b/tests/test_plan_runner.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 import yaml
 
 from hpc_framework.plan_runner import (
@@ -13,28 +12,6 @@ from hpc_framework.plan_runner import (
     _solver_k,
     run_plan,
 )
-
-
-def test_plan_runner_rejects_enabled_greedy(tmp_path: Path):
-    """Se o plano declarar greedy.enabled=true, o executor deve falhar explicitamente."""
-    plan = {
-        "schema": "forja-exp-v1",
-        "experiment_id": "test-plan",
-        "solvers": {
-            "greedy": {"enabled": True},
-            "metis": {"enabled": True, "k": 2, "budget": {"type": "time", "seconds": 1}},
-            "kahip": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 1}},
-        },
-        "instances": {"base_dir": "data/instances/synthetic", "include": ["n2000_p50.json.gz"]},
-        "rng": {"seeds": [42]},
-        "output": {"raw_dir": "data/results_raw", "tables_dir": "data/results_parquet"},
-    }
-
-    plan_path = tmp_path / "plan.yaml"
-    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
-
-    with pytest.raises(NotImplementedError, match="greedy"):
-        run_plan(plan_path)
 
 
 def test_enabled_supported_solvers_returns_only_supported_enabled_solvers():

--- a/tests/test_plan_runner_greedy.py
+++ b/tests/test_plan_runner_greedy.py
@@ -1,0 +1,83 @@
+import gzip
+import json
+from pathlib import Path
+
+import yaml
+
+from hpc_framework.plan_runner import run_plan
+
+
+def _write_instance_edges(instances_dir: Path, n: int = 6) -> Path:
+    inst = {
+        "instance_id": "toy",
+        "nodes": [{"id": i, "velocity": 1.0 + 0.1 * i} for i in range(n)],
+        "edges": [[i, i + 1] for i in range(n - 1)],
+    }
+    ipath = instances_dir / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_run_plan_delegates_greedy_run_to_adapter(monkeypatch, tmp_path: Path):
+    calls = []
+
+    def fake_run_greedy_observation(inst, delta_v):
+        calls.append(
+            {
+                "instance_id": inst["instance_id"],
+                "delta_v": delta_v,
+            }
+        )
+        return {
+            "labels": [0, 1, 0, 1, 0, 1],
+            "observed_k": 2,
+            "cutsize_best": 5,
+        }
+
+    import hpc_framework.plan_runner as plan_runner_mod
+
+    monkeypatch.setattr(
+        plan_runner_mod,
+        "run_greedy_observation",
+        fake_run_greedy_observation,
+        raising=False,
+    )
+
+    instances_dir = tmp_path / "instances"
+    instances_dir.mkdir()
+    _write_instance_edges(instances_dir, n=6)
+
+    raw_dir = tmp_path / "raw"
+    tables_dir = tmp_path / "tables"
+
+    plan = {
+        "schema": "forja-exp-v1",
+        "experiment_id": "greedy-plan",
+        "solvers": {
+            "greedy": {
+                "enabled": True,
+                "params": {"delta_v": 0.25},
+            },
+            "metis": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+            "kahip": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+        },
+        "instances": {
+            "base_dir": str(instances_dir),
+            "include": ["toy.json.gz"],
+        },
+        "rng": {"seeds": [42]},
+        "output": {
+            "raw_dir": str(raw_dir),
+            "tables_dir": str(tables_dir),
+        },
+    }
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    run_plan(plan_path)
+
+    assert len(calls) == 1
+    assert calls[0]["instance_id"] == "toy"
+    assert calls[0]["delta_v"] == 0.25

--- a/tests/test_plan_runner_greedy_output.py
+++ b/tests/test_plan_runner_greedy_output.py
@@ -1,0 +1,79 @@
+import gzip
+import json
+from pathlib import Path
+
+import yaml
+
+from hpc_framework.plan_runner import run_plan
+
+
+def _write_instance_edges(instances_dir: Path, n: int = 6) -> Path:
+    inst = {
+        "instance_id": "toy",
+        "nodes": [{"id": i, "velocity": 1.0 + 0.1 * i} for i in range(n)],
+        "edges": [[i, i + 1] for i in range(n - 1)],
+    }
+    ipath = instances_dir / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_run_plan_greedy_emits_json_output(monkeypatch, tmp_path: Path):
+    def fake_run_greedy_observation(inst, delta_v):
+        return {
+            "labels": [0, 1, 0, 1, 0, 1],
+            "observed_k": 2,
+            "cutsize_best": 5,
+        }
+
+    import hpc_framework.plan_runner as plan_runner_mod
+
+    monkeypatch.setattr(
+        plan_runner_mod,
+        "run_greedy_observation",
+        fake_run_greedy_observation,
+        raising=False,
+    )
+
+    instances_dir = tmp_path / "instances"
+    instances_dir.mkdir()
+    _write_instance_edges(instances_dir, n=6)
+
+    raw_dir = tmp_path / "raw"
+    tables_dir = tmp_path / "tables"
+
+    plan = {
+        "schema": "forja-exp-v1",
+        "experiment_id": "greedy-plan",
+        "solvers": {
+            "greedy": {
+                "enabled": True,
+                "params": {"delta_v": 0.25},
+            },
+            "metis": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+            "kahip": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+        },
+        "instances": {
+            "base_dir": str(instances_dir),
+            "include": ["toy.json.gz"],
+        },
+        "rng": {"seeds": [42]},
+        "output": {
+            "raw_dir": str(raw_dir),
+            "tables_dir": str(tables_dir),
+        },
+    }
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    run_plan(plan_path)
+
+    json_files = sorted(raw_dir.glob("*.json"))
+    assert len(json_files) == 1
+
+    data = json.loads(json_files[0].read_text(encoding="utf-8"))
+    assert data["algo"] == "greedy"
+    assert data["seed"] == 42
+    assert data["cutsize_best"] == 5

--- a/tests/test_plan_runner_greedy_schema.py
+++ b/tests/test_plan_runner_greedy_schema.py
@@ -1,0 +1,85 @@
+import gzip
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft7Validator
+
+from hpc_framework.plan_runner import run_plan
+
+
+def _write_instance_edges(instances_dir: Path, n: int = 6) -> Path:
+    inst = {
+        "instance_id": "toy",
+        "nodes": [{"id": i, "velocity": 1.0 + 0.1 * i} for i in range(n)],
+        "edges": [[i, i + 1] for i in range(n - 1)],
+    }
+    ipath = instances_dir / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_run_plan_greedy_emits_schema_valid_json(monkeypatch, tmp_path: Path):
+    def fake_run_greedy_observation(inst, delta_v):
+        return {
+            "labels": [0, 1, 0, 1, 0, 1],
+            "observed_k": 2,
+            "cutsize_best": 5,
+        }
+
+    import hpc_framework.plan_runner as plan_runner_mod
+
+    monkeypatch.setattr(
+        plan_runner_mod,
+        "run_greedy_observation",
+        fake_run_greedy_observation,
+        raising=False,
+    )
+
+    instances_dir = tmp_path / "instances"
+    instances_dir.mkdir()
+    _write_instance_edges(instances_dir, n=6)
+
+    raw_dir = tmp_path / "raw"
+    tables_dir = tmp_path / "tables"
+
+    plan = {
+        "schema": "forja-exp-v1",
+        "experiment_id": "greedy-plan",
+        "solvers": {
+            "greedy": {
+                "enabled": True,
+                "params": {"delta_v": 0.25},
+            },
+            "metis": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+            "kahip": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+        },
+        "instances": {
+            "base_dir": str(instances_dir),
+            "include": ["toy.json.gz"],
+        },
+        "rng": {"seeds": [42]},
+        "output": {
+            "raw_dir": str(raw_dir),
+            "tables_dir": str(tables_dir),
+        },
+    }
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    run_plan(plan_path)
+
+    json_files = sorted(raw_dir.glob("*.json"))
+    assert len(json_files) == 1
+
+    data = json.loads(json_files[0].read_text(encoding="utf-8"))
+    schema = json.loads(
+        Path("specs/jsonschema/solver_run.schema.v1.json").read_text(encoding="utf-8")
+    )
+
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+
+    assert errors == [], [f"{'.'.join(map(str, e.path)) or '<root>'}: {e.message}" for e in errors]


### PR DESCRIPTION
Resumo
- adiciona adaptador para integrar o baseline guloso ao fluxo declarativo
- converte instância JSON para grafo NetworkX
- converte clusters do greedy para labels zero-based
- produz observação mínima auditável do greedy
- faz o plan runner delegar greedy e persistir artefato compatível com o schema

Cobertura desta PR
- testes do adaptador
- testes de observação mínima
- testes de integração do greedy no plan runner
- teste de validade do JSON do greedy no schema v1

Observação
- esta PR não altera a lógica interna da heurística gulosa
- esta PR trata apenas da camada de adaptação e integração
