### PR TITLE
chore: re-enable greedy in official experiment plans

### DIFF
--- a/configs/plan_phase_1.yaml
+++ b/configs/plan_phase_1.yaml
@@ -32,7 +32,7 @@ instances:
   - cv_degree
 solvers:
   greedy:
-    enabled: false
+    enabled: true
     params:
       delta_v: 0.1
     budget:

--- a/configs/plan_phase_1_pilot.yaml
+++ b/configs/plan_phase_1_pilot.yaml
@@ -32,7 +32,7 @@ instances:
   - cv_degree
 solvers:
   greedy:
-    enabled: false
+    enabled: true
     params:
       delta_v: 0.1
     budget:

--- a/tests/test_plan_configs.py
+++ b/tests/test_plan_configs.py
@@ -7,17 +7,17 @@ def _load_yaml(path: str) -> dict:
     return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
 
 
-def test_phase1_plan_does_not_enable_unsupported_greedy():
+def test_phase1_plan_enables_greedy():
     plan = _load_yaml("configs/plan_phase_1.yaml")
     solvers = plan.get("solvers", {}) or {}
     greedy = solvers.get("greedy", {}) or {}
 
-    assert greedy.get("enabled", False) is False
+    assert greedy.get("enabled", False) is True
 
 
-def test_phase1_pilot_plan_does_not_enable_unsupported_greedy():
+def test_phase1_pilot_plan_enables_greedy():
     plan = _load_yaml("configs/plan_phase_1_pilot.yaml")
     solvers = plan.get("solvers", {}) or {}
     greedy = solvers.get("greedy", {}) or {}
 
-    assert greedy.get("enabled", False) is False
+    assert greedy.get("enabled", False) is True


### PR DESCRIPTION
Resumo
- reativa `greedy` nos planos oficiais de experimento
- alinha os YAMLs oficiais ao estado real do repositório após a integração do baseline guloso ao fluxo declarativo

Cobertura desta PR
- atualização de `plan_phase_1.yaml`
- atualização de `plan_phase_1_pilot.yaml`
- teste que fixa `greedy.enabled: true` nos planos oficiais

Observação
- esta PR não altera a lógica interna da heurística gulosa
- esta PR só sincroniza os planos oficiais com a capacidade já existente do pipeline
