### PR TITLE
fix: isolate artifact paths by experimental configuration

### DIFF
--- a/src/hpc_framework/plan_runner.py
+++ b/src/hpc_framework/plan_runner.py
@@ -143,7 +143,8 @@ def _write_greedy_result(
     budget_time_ms: int,
     obs: dict,
 ) -> None:
-    out_json = raw_dir / f"{Path(instance_name).name}__greedy__seed{seed}.json"
+    delta_tag = f"{float(delta_v):.2f}"
+    out_json = raw_dir / f"{Path(instance_name).name}__greedy__dv{delta_tag}__seed{seed}.json"
 
     labels = obs["labels"]
     labels_json = labels.tolist() if hasattr(labels, "tolist") else list(labels)
@@ -224,8 +225,13 @@ def run_plan(plan_path: Path) -> None:
             continue
 
         stem = Path(run["instance"]).name
-        out_json = raw_dir / f"{stem}__{run['solver']}__seed{run['seed']}.json"
-        workdir = raw_dir / f"run_{run['solver']}__{stem}__seed{run['seed']}"
+        beta_tag = f"{float(run['beta']):.2f}"
+        out_json = raw_dir / (
+            f"{stem}__{run['solver']}__k{run['k']}__b{beta_tag}__seed{run['seed']}.json"
+        )
+        workdir = raw_dir / (
+            f"run_{run['solver']}__{stem}__k{run['k']}__b{beta_tag}__seed{run['seed']}"
+        )
 
         run_one(
             instance_path=instance_path,

--- a/tests/test_plan_runner_artifact_namespace.py
+++ b/tests/test_plan_runner_artifact_namespace.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import yaml
+
+from hpc_framework.plan_runner import run_plan
+
+
+def test_run_plan_metis_names_out_json_and_workdir_with_k_and_beta(monkeypatch, tmp_path: Path):
+    calls = []
+
+    def fake_run_one(**kwargs):
+        calls.append(kwargs)
+        return object()
+
+    import hpc_framework.plan_runner as plan_runner_mod
+
+    monkeypatch.setattr(plan_runner_mod, "run_one", fake_run_one, raising=False)
+
+    instances_dir = tmp_path / "instances"
+    instances_dir.mkdir()
+    (instances_dir / "toy.json.gz").write_text("placeholder", encoding="utf-8")
+
+    raw_dir = tmp_path / "raw"
+    tables_dir = tmp_path / "tables"
+
+    plan = {
+        "schema": "forja-exp-v1",
+        "experiment_id": "namespace-test",
+        "solvers": {
+            "greedy": {"enabled": False},
+            "metis": {"enabled": True, "k": 8, "budget": {"type": "time", "seconds": 5}},
+            "kahip": {"enabled": False, "k": 8, "budget": {"type": "time", "seconds": 5}},
+        },
+        "instances": {
+            "base_dir": str(instances_dir),
+            "include": ["toy.json.gz"],
+        },
+        "rng": {"seeds": [42]},
+        "output": {
+            "raw_dir": str(raw_dir),
+            "tables_dir": str(tables_dir),
+        },
+    }
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    run_plan(plan_path)
+
+    assert len(calls) == 1
+    call = calls[0]
+
+    out_name = call["out_json"].name
+    work_name = call["workdir"].name
+
+    assert "k8" in out_name
+    assert "b0.03" in out_name
+    assert "k8" in work_name
+    assert "b0.03" in work_name

--- a/tests/test_plan_runner_greedy_namespace.py
+++ b/tests/test_plan_runner_greedy_namespace.py
@@ -1,0 +1,80 @@
+import gzip
+import json
+from pathlib import Path
+
+import yaml
+
+from hpc_framework.plan_runner import run_plan
+
+
+def _write_instance_edges(instances_dir: Path, n: int = 6) -> Path:
+    inst = {
+        "instance_id": "toy",
+        "nodes": [{"id": i, "velocity": 1.0 + 0.1 * i} for i in range(n)],
+        "edges": [[i, i + 1] for i in range(n - 1)],
+    }
+    ipath = instances_dir / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_run_plan_greedy_names_output_with_delta_v(monkeypatch, tmp_path: Path):
+    def fake_run_greedy_observation(inst, delta_v):
+        return {
+            "labels": [0, 1, 0, 1, 0, 1],
+            "observed_k": 2,
+            "cutsize_best": 5,
+        }
+
+    import hpc_framework.plan_runner as plan_runner_mod
+
+    monkeypatch.setattr(
+        plan_runner_mod,
+        "run_greedy_observation",
+        fake_run_greedy_observation,
+        raising=False,
+    )
+
+    instances_dir = tmp_path / "instances"
+    instances_dir.mkdir()
+    _write_instance_edges(instances_dir, n=6)
+
+    raw_dir = tmp_path / "raw"
+    tables_dir = tmp_path / "tables"
+
+    plan = {
+        "schema": "forja-exp-v1",
+        "experiment_id": "greedy-namespace-test",
+        "solvers": {
+            "greedy": {
+                "enabled": True,
+                "params": {"delta_v": 0.25},
+                "budget": {"type": "time", "seconds": 5},
+            },
+            "metis": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+            "kahip": {"enabled": False, "k": 2, "budget": {"type": "time", "seconds": 5}},
+        },
+        "instances": {
+            "base_dir": str(instances_dir),
+            "include": ["toy.json.gz"],
+        },
+        "rng": {"seeds": [42]},
+        "output": {
+            "raw_dir": str(raw_dir),
+            "tables_dir": str(tables_dir),
+        },
+    }
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    run_plan(plan_path)
+
+    json_files = sorted(raw_dir.glob("*.json"))
+    assert len(json_files) == 1
+
+    out_name = json_files[0].name
+    assert "greedy" in out_name
+    assert "dv0.25" in out_name
+    assert "seed42" in out_name


### PR DESCRIPTION
Resumo
- isola nomes de artefatos e diretórios de trabalho por configuração experimental
- inclui `k` e `beta` no namespace de `metis`/`kahip`
- inclui `delta_v` no namespace do `greedy`

Cobertura desta PR
- teste de namespace para `metis`
- teste de namespace para `greedy`
- ajuste do `plan_runner` para evitar colisão de resultados entre configurações diferentes

Observação
- esta PR não altera a lógica interna das heurísticas
- esta PR trata apenas da integridade e rastreabilidade dos artefatos experimentais
