### PR TITLE
feat: integrate simulated annealing into runner and cli

### DIFF
--- a/src/hpc_framework/cli.py
+++ b/src/hpc_framework/cli.py
@@ -12,7 +12,7 @@ from .runner import run_one
 
 def _add_single_run_arguments(p: argparse.ArgumentParser) -> None:
     p.add_argument("--instance", required=True, help="Arquivo da instância (.json|.json.gz)")
-    p.add_argument("--algo", required=True, choices=["metis", "kahip"])
+    p.add_argument("--algo", required=True, choices=["metis", "kahip", "sa"])
     p.add_argument("--k", required=True, type=int)
     p.add_argument("--beta", required=True, type=float)
     p.add_argument("--budget-time-ms", required=True, type=int, dest="budget_time_ms")

--- a/src/hpc_framework/plan_runner.py
+++ b/src/hpc_framework/plan_runner.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code=import-untyped
 """Executor declarativo mínimo para campanhas descritas em YAML."""
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from heuristics.sa import SAConfig, SAResult, run_sa_partition
 

--- a/src/hpc_framework/runner.py
+++ b/src/hpc_framework/runner.py
@@ -1,4 +1,4 @@
-"""Orquestrador single-run para METIS/KaHIP.
+"""Orquestrador single-run para METIS/KaHIP/SA.
 Usado pelos testes e pelo CLI para exportar .graph, invocar o solver e salvar artefatos/JSON.
 """
 
@@ -21,6 +21,7 @@ from typing import Any
 
 import numpy as np
 
+from heuristics.sa import SAConfig, run_sa_partition
 from hpc_framework.solvers.common import read_partition_labels, write_metis_graph
 from hpc_framework.solvers.kahip import run_kaffpa
 from hpc_framework.solvers.metis import run_gpmetis
@@ -99,6 +100,24 @@ def extract_graph_from_instance(inst: dict[str, Any]) -> tuple[int, np.ndarray]:
     return n, edges_arr
 
 
+def _adj_from_edges(n: int, edges: np.ndarray) -> dict[int, set[int]]:
+    """Build an undirected adjacency map from an edge array."""
+    adj: dict[int, set[int]] = {i: set() for i in range(int(n))}
+    for u, v in edges:
+        ui = int(u)
+        vi = int(v)
+        if ui == vi:
+            continue
+        adj[ui].add(vi)
+        adj[vi].add(ui)
+    return adj
+
+
+def _labels_from_part_of(part_of: dict[int, int], n: int) -> np.ndarray:
+    """Convert a part-of mapping into a dense labels array."""
+    return np.asarray([int(part_of[i]) for i in range(int(n))], dtype=int)
+
+
 def _read_instance(p: Path) -> dict[str, Any]:
     """Lê JSON (possivelmente .gz) de instância."""
     if str(p).endswith(".gz"):
@@ -161,36 +180,95 @@ def run(
     # Medição de parede local (overhead do Python incluído) para debug
     t0_wall = time.perf_counter()
 
-    if algo == "metis":
-        res = run_gpmetis(graph_path, k=k, beta=beta, seed=seed, timeout_s=budget_time_ms / 1000.0)
-    elif algo == "kahip":
-        res = run_kaffpa(
-            graph_path,
-            k=k,
-            beta=beta,
-            seed=seed,
-            timeout_s=budget_time_ms / 1000.0,
-            preset=kahip_preset,
-        )
-    else:
-        raise ValueError("algo must be 'metis' or 'kahip'")
-
-    elapsed_wall = int((time.perf_counter() - t0_wall) * 1000)
-    solver_elapsed_ms = int(res.elapsed_ms) if res.elapsed_ms is not None else elapsed_wall
-
-    labels = (
-        read_partition_labels(res.part_path) if res.part_path and res.part_path.exists() else None
-    )
-    cut = compute_cutsize_edges_labels(edges, labels) if labels is not None else None
-
+    stdout = ""
+    stderr = ""
+    returncode: int | None = 0
+    part_file: Path | None = None
+    labels: np.ndarray | None = None
+    checkpoints: list[dict[str, int | None]] = []
+    cut: int | None = None
     feasible = None
     validation = None
-    if labels is not None:
+
+    if algo == "sa":
+        adj = _adj_from_edges(n, edges)
+        sa_result = run_sa_partition(
+            adj,
+            k=k,
+            epsilon=beta,
+            config=SAConfig(
+                seed=seed,
+                budget_time_ms=budget_time_ms,
+            ),
+        )
+        elapsed_wall = int((time.perf_counter() - t0_wall) * 1000)
+        solver_elapsed_ms = (
+            int(sa_result.elapsed_ms) if sa_result.elapsed_ms is not None else elapsed_wall
+        )
+
+        labels = _labels_from_part_of(sa_result.best_part_of, n)
+        cut = int(sa_result.best_cutsize)
+
+        part_file = workdir / "sa.part"
+        part_file.write_text(
+            "".join(f"{int(label)}\n" for label in labels.tolist()), encoding="utf-8"
+        )
+
         labels_norm = normalize_labels_zero_based(labels)
         feasible, validation = feasible_beta(labels_norm, k=k, beta=beta)
+        status_json = sa_result.status
+        checkpoints = [
+            {
+                "time_ms": int(cp.time_ms),
+                "cutsize_best": int(cp.cutsize_best),
+                "nfe": int(cp.nfe),
+            }
+            for cp in sa_result.checkpoints
+        ]
+    else:
+        if algo == "metis":
+            res = run_gpmetis(
+                graph_path, k=k, beta=beta, seed=seed, timeout_s=budget_time_ms / 1000.0
+            )
+        elif algo == "kahip":
+            res = run_kaffpa(
+                graph_path,
+                k=k,
+                beta=beta,
+                seed=seed,
+                timeout_s=budget_time_ms / 1000.0,
+                preset=kahip_preset,
+            )
+        else:
+            raise ValueError("algo must be 'metis', 'kahip' or 'sa'")
 
-    # Mapeia status do solver para o status esperado pelos testes de runner
-    status_json = res.status if res.status in {"ok", "timeout"} else "solver_failed"
+        elapsed_wall = int((time.perf_counter() - t0_wall) * 1000)
+        solver_elapsed_ms = int(res.elapsed_ms) if res.elapsed_ms is not None else elapsed_wall
+
+        stdout = res.stdout
+        stderr = res.stderr
+        returncode = res.returncode
+
+        labels = (
+            read_partition_labels(res.part_path)
+            if res.part_path and res.part_path.exists()
+            else None
+        )
+        cut = compute_cutsize_edges_labels(edges, labels) if labels is not None else None
+
+        if labels is not None:
+            labels_norm = normalize_labels_zero_based(labels)
+            feasible, validation = feasible_beta(labels_norm, k=k, beta=beta)
+
+        status_json = res.status if res.status in {"ok", "timeout"} else "solver_failed"
+        part_file = res.part_path if res.part_path and res.part_path.exists() else None
+        checkpoints = [
+            {
+                "time_ms": solver_elapsed_ms,
+                "cutsize_best": int(cut) if cut is not None else None,
+                "nfe": None,
+            }
+        ]
 
     # Persistência do JSON (apenas tipos nativos)
     out = {
@@ -202,10 +280,10 @@ def run(
         "seed": seed,
         "budget_time_ms": budget_time_ms,
         "status": status_json,
-        "returncode": res.returncode,
+        "returncode": returncode,
         "elapsed_ms": solver_elapsed_ms,
-        "stdout": res.stdout,
-        "stderr": res.stderr,
+        "stdout": stdout,
+        "stderr": stderr,
         "metrics": {
             "cutsize_best": int(cut) if cut is not None else None,
             "n_nodes": int(n),
@@ -215,19 +293,13 @@ def run(
         "paths": {
             "workdir": str(workdir),
             "graph_path": str(graph_path),
-            "part_path": str(res.part_path) if res.part_path else None,
+            "part_path": str(part_file) if part_file else None,
         },
         "env": env_info,
         "tools": tool_info,
         "feasible": feasible,
         "validation": validation,
-        "checkpoints": [
-            {
-                "time_ms": solver_elapsed_ms,
-                "cutsize_best": int(cut) if cut is not None else None,
-                "nfe": None,
-            }
-        ],
+        "checkpoints": checkpoints,
         "schema_version": "1.0.0",
         "schema_path": "specs/jsonschema/solver_run.schema.v1.json",
         # Campos legados preservados por compatibilidade:
@@ -242,8 +314,8 @@ def run(
         algo=algo,
         status=status_json,
         cut=cut,
-        elapsed_ms=solver_elapsed_ms,  # Prioriza o tempo do solver; fallback controlado
-        part_file=res.part_path if res.part_path and res.part_path.exists() else None,
+        elapsed_ms=solver_elapsed_ms,
+        part_file=part_file,
     )
 
 

--- a/tests/test_cli_single_run_sa.py
+++ b/tests/test_cli_single_run_sa.py
@@ -1,0 +1,55 @@
+import gzip
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from hpc_framework.cli import main
+
+
+def _write_instance_edges(tmp_path: Path, n: int = 10) -> Path:
+    edges = [[i, i + 1] for i in range(n - 1)]
+    inst = {"instance_id": "toy", "num_nodes": n, "edges": edges}
+    ipath = tmp_path / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_cli_single_run_accepts_sa_and_writes_output(tmp_path: Path):
+    inst_path = _write_instance_edges(tmp_path, n=10)
+    out_json = tmp_path / "out_sa.json"
+    workdir = tmp_path / "work"
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        main(
+            [
+                "single-run",
+                "--instance",
+                str(inst_path),
+                "--algo",
+                "sa",
+                "--k",
+                "2",
+                "--beta",
+                "0.10",
+                "--budget-time-ms",
+                "5000",
+                "--seed",
+                "42",
+                "--out",
+                str(out_json),
+                "--workdir",
+                str(workdir),
+            ]
+        )
+
+    cli_obj = json.loads(buf.getvalue())
+    assert cli_obj["algo"] == "sa"
+    assert cli_obj["status"] == "ok"
+    assert out_json.exists()
+
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+    assert data["algo"] == "sa"
+    assert data["seed"] == 42

--- a/tests/test_runner_sa.py
+++ b/tests/test_runner_sa.py
@@ -1,0 +1,58 @@
+import gzip
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+from hpc_framework.runner import run_one
+
+
+def _write_instance_edges(tmp_path: Path, n: int = 10) -> Path:
+    edges = [[i, i + 1] for i in range(n - 1)]
+    inst = {"instance_id": "toy", "num_nodes": n, "edges": edges}
+    ipath = tmp_path / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_runner_sa_single_run_emits_schema_compatible_output(tmp_path: Path):
+    inst_path = _write_instance_edges(tmp_path, n=12)
+    out_json = tmp_path / "out_sa.json"
+    workdir = tmp_path / "work"
+
+    run_one(
+        instance_path=inst_path,
+        algo="sa",
+        k=3,
+        beta=0.10,
+        seed=42,
+        budget_time_ms=5000,
+        out_json=out_json,
+        workdir=workdir,
+        kahip_preset="fast",
+        log_level="info",
+    )
+
+    assert out_json.exists()
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+
+    assert data["algo"] == "sa"
+    assert data["instance_id"] == "toy"
+    assert data["k"] == 3
+    assert data["beta"] == 0.10
+    assert data["seed"] == 42
+    assert data["status"] == "ok"
+    assert isinstance(data["elapsed_ms"], int)
+    assert data["elapsed_ms"] >= 0
+    assert Path(data["paths"]["workdir"]).exists()
+    assert Path(data["paths"]["graph_path"]).exists()
+    assert Path(data["paths"]["part_path"]).exists()
+    assert len(data["checkpoints"]) >= 1
+    assert data["checkpoints"][-1]["nfe"] >= 0
+    assert data["checkpoints"][-1]["cutsize_best"] == data["cutsize_best"]
+
+    schema_path = Path("specs/jsonschema/solver_run.schema.v1.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    errors = sorted(Draft7Validator(schema).iter_errors(data), key=lambda e: list(e.path))
+    assert errors == [], [f"{'.'.join(map(str, e.path)) or '<root>'}: {e.message}" for e in errors]


### PR DESCRIPTION
## Summary
- integrate canonical simulated annealing into `runner.py` single-run execution
- extend CLI single-run mode to accept `--algo sa`
- add focused tests for SA runner output and CLI single-run execution

## Validation
- `poetry run pytest -q tests/test_sa_scaffold.py tests/test_plan_runner_sa.py tests/test_runner_sa.py tests/test_cli_single_run_sa.py tests/test_results_schema.py tests/test_runner_smoke.py`
- `poetry run pytest -q`

## Scope boundary
- this PR completes SA support in the current repository surface
- ILS, GRASP, and TS remain out of scope
