### PR TITLE
feat: add canonical iterated local search scaffold

### DIFF
--- a/src/heuristics/ils.py
+++ b/src/heuristics/ils.py
@@ -1,0 +1,200 @@
+"""Canonical iterated local search scaffold for k-way graph partitioning.
+
+This module keeps ILS local to the canonical GPP state representation. It does
+not yet extend the official runner or CLI surfaces. The goal is to validate a
+deterministic perturbation + descent kernel before wiring ILS into the
+declarative execution flow.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+
+from gpp_core.operator import (
+    Block,
+    PartitionState,
+    Vertex,
+    apply_move,
+    eval_move_delta_cut,
+    is_move_feasible,
+)
+from heuristics.sa import SACheckpoint, build_initial_state
+
+
+@dataclass(frozen=True)
+class ILSConfig:
+    """Configuration of the canonical ILS scaffold."""
+
+    seed: int
+    budget_time_ms: int
+    max_iters: int = 100
+    perturb_moves: int = 2
+    checkpoint_every_iter: int = 1
+
+
+@dataclass(frozen=True)
+class ILSResult:
+    """Structured result returned by the canonical ILS scaffold."""
+
+    best_part_of: dict[Vertex, Block]
+    best_cutsize: int
+    elapsed_ms: int
+    nfe: int
+    checkpoints: list[SACheckpoint]
+    status: str
+
+
+def clone_state(state: PartitionState) -> PartitionState:
+    """Return a detached copy of a partition state."""
+    return PartitionState(
+        adj=state.adj,
+        part_of=dict(state.part_of),
+        block_size=dict(state.block_size),
+        k=state.k,
+        epsilon=state.epsilon,
+        cutsize=int(state.cutsize),
+        boundary=set(state.boundary),
+    )
+
+
+def first_improvement_descent(
+    state: PartitionState,
+    *,
+    rng: random.Random,
+    nfe_start: int = 0,
+) -> tuple[PartitionState, int]:
+    """Run first-improvement local descent until no improving 1-move exists."""
+    nfe = int(nfe_start)
+
+    while True:
+        improved = False
+        vertices = list(state.boundary) if state.boundary else list(state.part_of.keys())
+        rng.shuffle(vertices)
+
+        for v in vertices:
+            targets = list(range(state.k))
+            rng.shuffle(targets)
+
+            for target in targets:
+                if target == state.part_of[v]:
+                    continue
+                if not is_move_feasible(state, v, target):
+                    continue
+
+                delta = eval_move_delta_cut(state, v, target)
+                nfe += 1
+
+                if delta < 0:
+                    apply_move(state, v, target)
+                    improved = True
+                    break
+
+            if improved:
+                break
+
+        if not improved:
+            return state, nfe
+
+
+def perturb_state(state: PartitionState, *, rng: random.Random, moves: int) -> None:
+    """Apply a small number of feasible random moves in-place."""
+    vertices = list(state.part_of.keys())
+
+    for _ in range(max(1, int(moves))):
+        rng.shuffle(vertices)
+        moved = False
+
+        for v in vertices:
+            targets = list(range(state.k))
+            rng.shuffle(targets)
+
+            for target in targets:
+                if target == state.part_of[v]:
+                    continue
+                if not is_move_feasible(state, v, target):
+                    continue
+
+                apply_move(state, v, target)
+                moved = True
+                break
+
+            if moved:
+                break
+
+
+def run_ils_partition(
+    adj: dict[Vertex, set[Vertex]],
+    *,
+    k: int,
+    epsilon: float,
+    config: ILSConfig,
+) -> ILSResult:
+    """Run a minimal deterministic ILS kernel over the canonical GPP state."""
+    rng = random.Random(config.seed)
+
+    current = build_initial_state(adj, k=k, epsilon=epsilon, seed=config.seed)
+    current, nfe = first_improvement_descent(current, rng=rng, nfe_start=0)
+
+    best = clone_state(current)
+    best_cutsize = int(current.cutsize)
+    checkpoints: list[SACheckpoint] = [SACheckpoint(time_ms=0, cutsize_best=best_cutsize, nfe=nfe)]
+
+    t0 = time.perf_counter()
+    status = "ok"
+
+    for iteration in range(int(config.max_iters)):
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        if elapsed_ms >= int(config.budget_time_ms):
+            status = "timeout"
+            break
+
+        candidate = clone_state(current)
+        perturb_state(candidate, rng=rng, moves=config.perturb_moves)
+        candidate, nfe = first_improvement_descent(candidate, rng=rng, nfe_start=nfe)
+
+        if candidate.cutsize <= current.cutsize:
+            current = clone_state(candidate)
+
+        if candidate.cutsize < best_cutsize:
+            best = clone_state(candidate)
+            best_cutsize = int(candidate.cutsize)
+
+        if (iteration + 1) % int(config.checkpoint_every_iter) == 0:
+            checkpoints.append(
+                SACheckpoint(
+                    time_ms=int((time.perf_counter() - t0) * 1000),
+                    cutsize_best=best_cutsize,
+                    nfe=nfe,
+                )
+            )
+
+    elapsed_ms = int((time.perf_counter() - t0) * 1000)
+    if checkpoints[-1].nfe != nfe or checkpoints[-1].cutsize_best != best_cutsize:
+        checkpoints.append(
+            SACheckpoint(
+                time_ms=elapsed_ms,
+                cutsize_best=best_cutsize,
+                nfe=nfe,
+            )
+        )
+
+    return ILSResult(
+        best_part_of=dict(best.part_of),
+        best_cutsize=best_cutsize,
+        elapsed_ms=elapsed_ms,
+        nfe=nfe,
+        checkpoints=checkpoints,
+        status=status,
+    )
+
+
+__all__ = [
+    "ILSConfig",
+    "ILSResult",
+    "clone_state",
+    "first_improvement_descent",
+    "perturb_state",
+    "run_ils_partition",
+]

--- a/tests/test_ils_scaffold.py
+++ b/tests/test_ils_scaffold.py
@@ -1,0 +1,100 @@
+"""Tests for the canonical ILS scaffold."""
+
+from __future__ import annotations
+
+import random
+
+from gpp_core.operator import compute_cutsize_naive
+from heuristics.ils import (
+    ILSConfig,
+    clone_state,
+    first_improvement_descent,
+    perturb_state,
+    run_ils_partition,
+)
+from heuristics.sa import build_initial_state
+
+
+def _path_adj(n: int) -> dict[int, set[int]]:
+    adj = {i: set() for i in range(n)}
+    for i in range(n - 1):
+        adj[i].add(i + 1)
+        adj[i + 1].add(i)
+    return adj
+
+
+def test_first_improvement_descent_never_worsens_cut():
+    adj = _path_adj(12)
+    state = build_initial_state(adj, k=3, epsilon=0.10, seed=42)
+    initial_cut = state.cutsize
+
+    result_state, nfe = first_improvement_descent(
+        clone_state(state),
+        rng=random.Random(42),
+        nfe_start=0,
+    )
+
+    assert nfe >= 0
+    assert result_state.cutsize <= initial_cut
+    assert result_state.cutsize == compute_cutsize_naive(adj, result_state.part_of)
+
+
+def test_perturb_state_keeps_partition_defined():
+    adj = _path_adj(10)
+    state = build_initial_state(adj, k=2, epsilon=0.10, seed=7)
+
+    perturb_state(state, rng=random.Random(7), moves=3)
+
+    assert len(state.part_of) == 10
+    assert sum(state.block_size.values()) == 10
+    assert state.cutsize == compute_cutsize_naive(adj, state.part_of)
+
+
+def test_run_ils_partition_returns_valid_anytime_result():
+    adj = _path_adj(14)
+    initial = build_initial_state(adj, k=2, epsilon=0.10, seed=11)
+
+    result = run_ils_partition(
+        adj,
+        k=2,
+        epsilon=0.10,
+        config=ILSConfig(
+            seed=11,
+            budget_time_ms=200,
+            max_iters=40,
+            perturb_moves=2,
+            checkpoint_every_iter=2,
+        ),
+    )
+
+    assert result.status in {"ok", "timeout"}
+    assert result.best_cutsize <= initial.cutsize
+    assert result.best_cutsize == compute_cutsize_naive(adj, result.best_part_of)
+    assert result.nfe >= 0
+    assert len(result.checkpoints) >= 1
+
+    times = [cp.time_ms for cp in result.checkpoints]
+    nfes = [cp.nfe for cp in result.checkpoints]
+
+    assert times == sorted(times)
+    assert nfes == sorted(nfes)
+    assert result.checkpoints[-1].cutsize_best == result.best_cutsize
+    assert result.checkpoints[-1].nfe == result.nfe
+
+
+def test_run_ils_partition_is_deterministic_with_fixed_seed_and_iters():
+    adj = _path_adj(10)
+    cfg = ILSConfig(
+        seed=123,
+        budget_time_ms=10_000,
+        max_iters=20,
+        perturb_moves=2,
+        checkpoint_every_iter=1,
+    )
+
+    r1 = run_ils_partition(adj, k=2, epsilon=0.10, config=cfg)
+    r2 = run_ils_partition(adj, k=2, epsilon=0.10, config=cfg)
+
+    assert r1.best_part_of == r2.best_part_of
+    assert r1.best_cutsize == r2.best_cutsize
+    assert r1.nfe == r2.nfe


### PR DESCRIPTION
## Summary
- add a canonical iterated local search scaffold over `PartitionState`
- keep the scope intentionally local, without wiring ILS into the official runner yet
- add focused tests for deterministic descent, deterministic seeded execution, perturbation validity, and anytime checkpoint behavior

## Validation
- `poetry run pytest -q tests/test_ils_scaffold.py tests/test_sa_scaffold.py tests/test_operator.py`
- `poetry run pytest -q`

## Notes
- this PR validates only the canonical ILS search kernel
- runner/plan/CLI integration will come in a later PR after the search core is frozen
- GRASP and TS remain out of scope here
