### PR TITLE
feat: add canonical GRASP scaffold

### DIFF
--- a/src/heuristics/grasp.py
+++ b/src/heuristics/grasp.py
@@ -1,0 +1,216 @@
+"""Canonical GRASP scaffold for k-way graph partitioning.
+
+This module keeps GRASP local to the canonical GPP state representation. It
+does not yet extend the official runner or CLI surfaces. The goal is to
+validate a deterministic greedy-randomized construction + local descent kernel
+before wiring GRASP into the declarative execution flow.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import time
+from dataclasses import dataclass
+
+from gpp_core.operator import (
+    Block,
+    PartitionState,
+    Vertex,
+    compute_cutsize_naive,
+    recompute_boundary,
+)
+from heuristics.ils import first_improvement_descent
+from heuristics.sa import SACheckpoint
+
+
+@dataclass(frozen=True)
+class GRASPConfig:
+    """Configuration of the canonical GRASP scaffold."""
+
+    seed: int
+    budget_time_ms: int
+    alpha: float = 0.30
+    max_iters: int = 100
+    checkpoint_every_iter: int = 1
+
+
+@dataclass(frozen=True)
+class GRASPResult:
+    """Structured result returned by the canonical GRASP scaffold."""
+
+    best_part_of: dict[Vertex, Block]
+    best_cutsize: int
+    elapsed_ms: int
+    nfe: int
+    checkpoints: list[SACheckpoint]
+    status: str
+
+
+def construct_greedy_randomized_state(
+    adj: dict[Vertex, set[Vertex]],
+    *,
+    k: int,
+    epsilon: float,
+    rng: random.Random,
+    alpha: float,
+) -> PartitionState:
+    """Build a balanced greedy-randomized initial partition."""
+    if k <= 0:
+        raise ValueError("k must be positive")
+    if k > len(adj):
+        raise ValueError("k cannot exceed the number of vertices")
+    if not 0.0 <= float(alpha) <= 1.0:
+        raise ValueError("alpha must be in [0,1]")
+
+    vertices = list(adj.keys())
+    rng.shuffle(vertices)
+
+    n = len(vertices)
+    max_block_size = math.ceil((1.0 + epsilon) * n / k)
+
+    # Target quotas keep the constructor balanced whenever exact balancing is
+    # possible. This is stricter than the feasibility cap and matches the
+    # deterministic scaffold contract used in the tests.
+    base_quota = n // k
+    remainder = n % k
+    target_size: dict[Block, int] = {b: base_quota + (1 if b < remainder else 0) for b in range(k)}
+
+    part_of: dict[Vertex, Block] = {}
+    block_size: dict[Block, int] = dict.fromkeys(range(k), 0)
+
+    # Seed one vertex per block so every block starts non-empty.
+    for block, v in enumerate(vertices[:k]):
+        part_of[v] = block
+        block_size[block] += 1
+
+    for v in vertices[k:]:
+        candidates: list[tuple[int, Block]] = []
+
+        for block in range(k):
+            if block_size[block] >= max_block_size:
+                continue
+            if block_size[block] >= target_size[block]:
+                continue
+
+            # Greedy score: number of already-assigned incident edges that would
+            # become cut edges if v were placed in this block.
+            score = sum(1 for u in adj[v] if u in part_of and part_of[u] != block)
+            candidates.append((score, block))
+
+        if not candidates:
+            remaining_capacity = {
+                block: target_size[block] - block_size[block] for block in range(k)
+            }
+            positive_blocks = [block for block, cap in remaining_capacity.items() if cap > 0]
+            if positive_blocks:
+                min_size = min(block_size[block] for block in positive_blocks)
+                tied = [block for block in positive_blocks if block_size[block] == min_size]
+            else:
+                min_size = min(block_size.values())
+                tied = [block for block, size in block_size.items() if size == min_size]
+            chosen = rng.choice(tied)
+        else:
+            scores = [score for score, _block in candidates]
+            s_min = min(scores)
+            s_max = max(scores)
+            threshold = s_min + float(alpha) * (s_max - s_min)
+            rcl = [block for score, block in candidates if score <= threshold + 1e-12]
+            chosen = rng.choice(rcl)
+
+        part_of[v] = chosen
+        block_size[chosen] += 1
+
+    cutsize = compute_cutsize_naive(adj, part_of)
+    boundary = recompute_boundary(adj, part_of)
+
+    return PartitionState(
+        adj=adj,
+        part_of=part_of,
+        block_size=block_size,
+        k=k,
+        epsilon=epsilon,
+        cutsize=cutsize,
+        boundary=boundary,
+    )
+
+
+def run_grasp_partition(
+    adj: dict[Vertex, set[Vertex]],
+    *,
+    k: int,
+    epsilon: float,
+    config: GRASPConfig,
+) -> GRASPResult:
+    """Run a minimal deterministic GRASP kernel over the canonical GPP state."""
+    rng = random.Random(config.seed)
+    t0 = time.perf_counter()
+
+    initial = construct_greedy_randomized_state(
+        adj,
+        k=k,
+        epsilon=epsilon,
+        rng=rng,
+        alpha=float(config.alpha),
+    )
+    initial, nfe = first_improvement_descent(initial, rng=rng, nfe_start=0)
+
+    best_part_of = dict(initial.part_of)
+    best_cutsize = int(initial.cutsize)
+    checkpoints: list[SACheckpoint] = [SACheckpoint(time_ms=0, cutsize_best=best_cutsize, nfe=nfe)]
+    status = "ok"
+
+    for iteration in range(1, int(config.max_iters)):
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        if elapsed_ms >= int(config.budget_time_ms):
+            status = "timeout"
+            break
+
+        candidate = construct_greedy_randomized_state(
+            adj,
+            k=k,
+            epsilon=epsilon,
+            rng=rng,
+            alpha=float(config.alpha),
+        )
+        candidate, nfe = first_improvement_descent(candidate, rng=rng, nfe_start=nfe)
+
+        if candidate.cutsize < best_cutsize:
+            best_part_of = dict(candidate.part_of)
+            best_cutsize = int(candidate.cutsize)
+
+        if iteration % int(config.checkpoint_every_iter) == 0:
+            checkpoints.append(
+                SACheckpoint(
+                    time_ms=int((time.perf_counter() - t0) * 1000),
+                    cutsize_best=best_cutsize,
+                    nfe=nfe,
+                )
+            )
+
+    elapsed_ms = int((time.perf_counter() - t0) * 1000)
+    if checkpoints[-1].nfe != nfe or checkpoints[-1].cutsize_best != best_cutsize:
+        checkpoints.append(
+            SACheckpoint(
+                time_ms=elapsed_ms,
+                cutsize_best=best_cutsize,
+                nfe=nfe,
+            )
+        )
+
+    return GRASPResult(
+        best_part_of=best_part_of,
+        best_cutsize=best_cutsize,
+        elapsed_ms=elapsed_ms,
+        nfe=nfe,
+        checkpoints=checkpoints,
+        status=status,
+    )
+
+
+__all__ = [
+    "GRASPConfig",
+    "GRASPResult",
+    "construct_greedy_randomized_state",
+    "run_grasp_partition",
+]

--- a/tests/test_grasp_scaffold.py
+++ b/tests/test_grasp_scaffold.py
@@ -1,0 +1,96 @@
+"""Tests for the canonical GRASP scaffold."""
+
+from __future__ import annotations
+
+import random
+
+from gpp_core.operator import compute_cutsize_naive
+from heuristics.grasp import GRASPConfig, construct_greedy_randomized_state, run_grasp_partition
+
+
+def _path_adj(n: int) -> dict[int, set[int]]:
+    adj = {i: set() for i in range(n)}
+    for i in range(n - 1):
+        adj[i].add(i + 1)
+        adj[i + 1].add(i)
+    return adj
+
+
+def test_construct_greedy_randomized_state_is_deterministic_and_balanced():
+    adj = _path_adj(10)
+
+    s1 = construct_greedy_randomized_state(
+        adj,
+        k=2,
+        epsilon=0.03,
+        rng=random.Random(42),
+        alpha=0.30,
+    )
+    s2 = construct_greedy_randomized_state(
+        adj,
+        k=2,
+        epsilon=0.03,
+        rng=random.Random(42),
+        alpha=0.30,
+    )
+
+    assert s1.part_of == s2.part_of
+    assert s1.block_size == s2.block_size
+    assert s1.cutsize == compute_cutsize_naive(adj, s1.part_of)
+    assert sorted(s1.block_size.values()) == [5, 5]
+
+
+def test_run_grasp_partition_returns_valid_anytime_result():
+    adj = _path_adj(14)
+    initial = construct_greedy_randomized_state(
+        adj,
+        k=2,
+        epsilon=0.10,
+        rng=random.Random(11),
+        alpha=0.30,
+    )
+
+    result = run_grasp_partition(
+        adj,
+        k=2,
+        epsilon=0.10,
+        config=GRASPConfig(
+            seed=11,
+            budget_time_ms=200,
+            alpha=0.30,
+            max_iters=40,
+            checkpoint_every_iter=2,
+        ),
+    )
+
+    assert result.status in {"ok", "timeout"}
+    assert result.best_cutsize <= initial.cutsize
+    assert result.best_cutsize == compute_cutsize_naive(adj, result.best_part_of)
+    assert result.nfe >= 0
+    assert len(result.checkpoints) >= 1
+
+    times = [cp.time_ms for cp in result.checkpoints]
+    nfes = [cp.nfe for cp in result.checkpoints]
+
+    assert times == sorted(times)
+    assert nfes == sorted(nfes)
+    assert result.checkpoints[-1].cutsize_best == result.best_cutsize
+    assert result.checkpoints[-1].nfe == result.nfe
+
+
+def test_run_grasp_partition_is_deterministic_with_fixed_seed_and_iters():
+    adj = _path_adj(10)
+    cfg = GRASPConfig(
+        seed=123,
+        budget_time_ms=10_000,
+        alpha=0.25,
+        max_iters=20,
+        checkpoint_every_iter=1,
+    )
+
+    r1 = run_grasp_partition(adj, k=2, epsilon=0.10, config=cfg)
+    r2 = run_grasp_partition(adj, k=2, epsilon=0.10, config=cfg)
+
+    assert r1.best_part_of == r2.best_part_of
+    assert r1.best_cutsize == r2.best_cutsize
+    assert r1.nfe == r2.nfe


### PR DESCRIPTION
## Summary
- add a canonical GRASP scaffold over `PartitionState`
- keep the scope intentionally local, without wiring GRASP into the official runner yet
- add focused tests for deterministic greedy-randomized construction, deterministic seeded execution, and anytime checkpoint behavior

## Validation
- `poetry run pytest -q tests/test_grasp_scaffold.py tests/test_ils_scaffold.py tests/test_sa_scaffold.py tests/test_operator.py`
- `poetry run pytest -q`

## Notes
- this PR validates only the canonical GRASP search kernel
- runner/plan/CLI integration will come in a later PR after the search core is frozen
- TS remains out of scope here
