### PR TITLE
feat: integrate GRASP into plan runner

### DIFF
--- a/specs/jsonschema/solver_run.schema.v1.json
+++ b/specs/jsonschema/solver_run.schema.v1.json
@@ -34,7 +34,8 @@
         "kahip",
         "greedy",
         "sa",
-        "ils"
+        "ils",
+        "grasp"
       ]
     },
     "k": {

--- a/src/hpc_framework/plan_runner.py
+++ b/src/hpc_framework/plan_runner.py
@@ -14,6 +14,7 @@ from typing import Any
 import numpy as np
 import yaml
 
+from heuristics.grasp import GRASPConfig, GRASPResult, run_grasp_partition
 from heuristics.ils import ILSConfig, ILSResult, run_ils_partition
 from heuristics.sa import SAConfig, SAResult, run_sa_partition
 
@@ -29,7 +30,7 @@ from .runner import (
 )
 from .solvers.common import write_metis_graph
 
-SUPPORTED_SOLVERS = ("metis", "kahip", "sa", "ils")
+SUPPORTED_SOLVERS = ("metis", "kahip", "sa", "ils", "grasp")
 MANIFEST_FIELDS = [
     "timestamp",
     "instance_id",
@@ -434,6 +435,84 @@ def _write_ils_result(
     return out_json
 
 
+def _write_grasp_result(
+    *,
+    raw_dir: Path,
+    instance_name: str,
+    instance_id: str,
+    n: int,
+    edges: Any,
+    k: int,
+    beta: float,
+    seed: int,
+    budget_time_ms: int,
+    result: GRASPResult,
+) -> Path:
+    """Persist a canonical GRASP run in the same JSON contract used by the runner."""
+    beta_tag = f"{float(beta):.2f}"
+    out_json = raw_dir / f"{Path(instance_name).name}__grasp__k{k}__b{beta_tag}__seed{seed}.json"
+    workdir = raw_dir / f"run_grasp__{Path(instance_name).name}__k{k}__b{beta_tag}__seed{seed}"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    graph_path = workdir / "graph.graph"
+    write_metis_graph(graph_path, int(n), edges)
+
+    labels = _labels_from_part_of(result.best_part_of, int(n))
+    labels_np = np.asarray(labels, dtype=int)
+
+    part_path = workdir / "grasp.part"
+    part_path.write_text("".join(f"{int(label)}\n" for label in labels), encoding="utf-8")
+
+    feasible, validation = feasible_beta(
+        normalize_labels_zero_based(labels_np),
+        k=int(k),
+        beta=float(beta),
+    )
+
+    payload = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "instance_id": instance_id,
+        "algo": "grasp",
+        "k": int(k),
+        "beta": float(beta),
+        "seed": int(seed),
+        "budget_time_ms": int(budget_time_ms),
+        "status": result.status,
+        "returncode": 0,
+        "elapsed_ms": int(result.elapsed_ms),
+        "stdout": "",
+        "stderr": "",
+        "metrics": {
+            "cutsize_best": int(result.best_cutsize),
+            "n_nodes": int(n),
+            "balance_tolerance": float(beta),
+            "imbalance_raw": None,
+        },
+        "paths": {
+            "workdir": str(workdir),
+            "graph_path": str(graph_path),
+            "part_path": str(part_path),
+        },
+        "env": _env_snapshot(),
+        "tools": _greedy_tools_snapshot(),
+        "feasible": feasible,
+        "validation": validation,
+        "checkpoints": [
+            {
+                "time_ms": int(cp.time_ms),
+                "cutsize_best": int(cp.cutsize_best),
+                "nfe": int(cp.nfe),
+            }
+            for cp in result.checkpoints
+        ],
+        "schema_version": "1.0.0",
+        "schema_path": "specs/jsonschema/solver_run.schema.v1.json",
+        "cutsize_best": int(result.best_cutsize),
+    }
+    out_json.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out_json
+
+
 def run_plan(plan_path: Path) -> None:
     """Executa uma campanha mínima a partir de um plano YAML."""
     plan = _load_plan(plan_path)
@@ -544,6 +623,41 @@ def run_plan(plan_path: Path) -> None:
                 seed=int(run["seed"]),
                 budget_time_ms=int(run["budget_time_ms"]),
                 result=ils_result,
+            )
+            produced_outputs.append(out_json)
+            continue
+        if run["solver"] == "grasp":
+            inst = _read_instance_json(instance_path)
+            n, edges = extract_graph_from_instance(inst)
+            adj = _adj_from_edges(n, edges)
+
+            grasp_cfg = (plan.get("solvers", {}) or {}).get("grasp", {}) or {}
+            grasp_params = grasp_cfg.get("params", {}) or {}
+
+            grasp_result = run_grasp_partition(
+                adj,
+                k=int(run["k"]),
+                epsilon=float(run["beta"]),
+                config=GRASPConfig(
+                    seed=int(run["seed"]),
+                    budget_time_ms=int(run["budget_time_ms"]),
+                    alpha=float(grasp_params.get("alpha", 0.30)),
+                    max_iters=int(grasp_params.get("max_iters", 100)),
+                    checkpoint_every_iter=int(grasp_params.get("checkpoint_every_iter", 1)),
+                ),
+            )
+
+            out_json = _write_grasp_result(
+                raw_dir=raw_dir,
+                instance_name=run["instance"],
+                instance_id=str(inst.get("instance_id", Path(run["instance"]).stem)),
+                n=int(n),
+                edges=edges,
+                k=int(run["k"]),
+                beta=float(run["beta"]),
+                seed=int(run["seed"]),
+                budget_time_ms=int(run["budget_time_ms"]),
+                result=grasp_result,
             )
             produced_outputs.append(out_json)
             continue

--- a/tests/test_plan_runner_grasp.py
+++ b/tests/test_plan_runner_grasp.py
@@ -1,0 +1,106 @@
+import csv
+import gzip
+import json
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft7Validator
+
+from hpc_framework.plan_runner import _enabled_supported_solvers, run_plan
+
+
+def _write_instance_edges(tmp_path: Path, n: int = 8) -> Path:
+    edges = [[i, i + 1] for i in range(n - 1)]
+    inst = {"instance_id": "toy", "num_nodes": n, "edges": edges}
+    ipath = tmp_path / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_enabled_supported_solvers_includes_grasp_when_enabled():
+    plan = {
+        "solvers": {
+            "metis": {"enabled": False},
+            "kahip": {"enabled": False},
+            "sa": {"enabled": False},
+            "ils": {"enabled": False},
+            "grasp": {"enabled": True},
+        }
+    }
+
+    assert _enabled_supported_solvers(plan) == ["grasp"]
+
+
+def test_run_plan_grasp_writes_schema_compatible_output_and_manifest(tmp_path: Path):
+    instances_dir = tmp_path / "instances"
+    instances_dir.mkdir()
+    _write_instance_edges(instances_dir, n=10)
+
+    raw_dir = tmp_path / "raw"
+    manifest_out = raw_dir / "manifest_index.csv"
+
+    plan = {
+        "schema": "forja-exp-v1",
+        "experiment_id": "test-grasp-plan",
+        "solvers": {
+            "metis": {"enabled": False},
+            "kahip": {"enabled": False},
+            "sa": {"enabled": False},
+            "ils": {"enabled": False},
+            "grasp": {
+                "enabled": True,
+                "k": 2,
+                "imbalance": 0.10,
+                "budget": {"type": "time", "seconds": 10},
+                "params": {
+                    "alpha": 0.30,
+                    "max_iters": 20,
+                    "checkpoint_every_iter": 1,
+                },
+            },
+        },
+        "instances": {
+            "base_dir": str(instances_dir),
+            "include": ["toy.json.gz"],
+            "manifest_out": str(manifest_out),
+        },
+        "rng": {"seeds": [42]},
+        "output": {"raw_dir": str(raw_dir)},
+    }
+
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan), encoding="utf-8")
+
+    run_plan(plan_path)
+
+    out_json = raw_dir / "toy.json.gz__grasp__k2__b0.10__seed42.json"
+    assert out_json.exists()
+
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+    assert data["algo"] == "grasp"
+    assert data["instance_id"] == "toy"
+    assert data["k"] == 2
+    assert data["beta"] == 0.10
+    assert data["seed"] == 42
+    assert data["status"] == "ok"
+    assert isinstance(data["elapsed_ms"], int)
+    assert data["elapsed_ms"] >= 0
+    assert len(data["checkpoints"]) >= 1
+    assert data["checkpoints"][-1]["nfe"] >= 0
+    assert data["checkpoints"][-1]["cutsize_best"] == data["cutsize_best"]
+    assert Path(data["paths"]["workdir"]).exists()
+    assert Path(data["paths"]["graph_path"]).exists()
+    assert Path(data["paths"]["part_path"]).exists()
+
+    schema_path = Path("specs/jsonschema/solver_run.schema.v1.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    errors = sorted(Draft7Validator(schema).iter_errors(data), key=lambda e: list(e.path))
+    assert errors == [], [f"{'.'.join(map(str, e.path)) or '<root>'}: {e.message}" for e in errors]
+
+    with manifest_out.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 1
+    assert rows[0]["algo"] == "grasp"
+    assert rows[0]["instance_id"] == "toy"


### PR DESCRIPTION
## Summary
- integrate canonical GRASP into the declarative `plan_runner`
- extend the solver run schema to accept `algo="grasp"`
- emit GRASP results with canonical checkpoints, `nfe`, feasibility metadata, and artifact paths
- add focused plan-runner tests for GRASP output + manifest generation

## Validation
- `poetry run pytest -q tests/test_grasp_scaffold.py tests/test_plan_runner_grasp.py tests/test_plan_runner_ils.py tests/test_plan_runner_sa.py tests/test_plan_runner.py tests/test_operator.py tests/test_results_schema.py`
- `poetry run pytest -q`

## Scope boundary
- this PR wires GRASP only into the declarative campaign flow
- it does not yet extend `runner.py` single-run or the CLI
- TS remains out of scope here
