### PR TITLE
feat: integrate GRASP into runner and cli

### DIFF
--- a/src/hpc_framework/cli.py
+++ b/src/hpc_framework/cli.py
@@ -12,7 +12,7 @@ from .runner import run_one
 
 def _add_single_run_arguments(p: argparse.ArgumentParser) -> None:
     p.add_argument("--instance", required=True, help="Arquivo da instância (.json|.json.gz)")
-    p.add_argument("--algo", required=True, choices=["metis", "kahip", "sa", "ils"])
+    p.add_argument("--algo", required=True, choices=["metis", "kahip", "sa", "ils", "grasp"])
     p.add_argument("--k", required=True, type=int)
     p.add_argument("--beta", required=True, type=float)
     p.add_argument("--budget-time-ms", required=True, type=int, dest="budget_time_ms")

--- a/src/hpc_framework/runner.py
+++ b/src/hpc_framework/runner.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import numpy as np
 
+from heuristics.grasp import GRASPConfig, run_grasp_partition
 from heuristics.ils import ILSConfig, run_ils_partition
 from heuristics.sa import SAConfig, run_sa_partition
 from hpc_framework.solvers.common import read_partition_labels, write_metis_graph
@@ -226,6 +227,41 @@ def run(
             }
             for cp in sa_result.checkpoints
         ]
+    elif algo == "grasp":
+        adj = _adj_from_edges(n, edges)
+        grasp_result = run_grasp_partition(
+            adj,
+            k=k,
+            epsilon=beta,
+            config=GRASPConfig(
+                seed=seed,
+                budget_time_ms=budget_time_ms,
+            ),
+        )
+        elapsed_wall = int((time.perf_counter() - t0_wall) * 1000)
+        solver_elapsed_ms = (
+            int(grasp_result.elapsed_ms) if grasp_result.elapsed_ms is not None else elapsed_wall
+        )
+
+        labels = _labels_from_part_of(grasp_result.best_part_of, n)
+        cut = int(grasp_result.best_cutsize)
+
+        part_file = workdir / "grasp.part"
+        part_file.write_text(
+            "".join(f"{int(label)}\n" for label in labels.tolist()), encoding="utf-8"
+        )
+
+        labels_norm = normalize_labels_zero_based(labels)
+        feasible, validation = feasible_beta(labels_norm, k=k, beta=beta)
+        status_json = grasp_result.status
+        checkpoints = [
+            {
+                "time_ms": int(cp.time_ms),
+                "cutsize_best": int(cp.cutsize_best),
+                "nfe": int(cp.nfe),
+            }
+            for cp in grasp_result.checkpoints
+        ]
     elif algo == "ils":
         adj = _adj_from_edges(n, edges)
         ils_result = run_ils_partition(
@@ -276,7 +312,7 @@ def run(
                 preset=kahip_preset,
             )
         else:
-            raise ValueError("algo must be 'metis', 'kahip', 'sa' or 'ils'")
+            raise ValueError("algo must be 'metis', 'kahip', 'sa', 'ils' or 'grasp'")
 
         elapsed_wall = int((time.perf_counter() - t0_wall) * 1000)
         solver_elapsed_ms = int(res.elapsed_ms) if res.elapsed_ms is not None else elapsed_wall

--- a/tests/test_cli_single_run_grasp.py
+++ b/tests/test_cli_single_run_grasp.py
@@ -1,0 +1,55 @@
+import gzip
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from hpc_framework.cli import main
+
+
+def _write_instance_edges(tmp_path: Path, n: int = 10) -> Path:
+    edges = [[i, i + 1] for i in range(n - 1)]
+    inst = {"instance_id": "toy", "num_nodes": n, "edges": edges}
+    ipath = tmp_path / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_cli_single_run_accepts_grasp_and_writes_output(tmp_path: Path):
+    inst_path = _write_instance_edges(tmp_path, n=10)
+    out_json = tmp_path / "out_grasp.json"
+    workdir = tmp_path / "work"
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        main(
+            [
+                "single-run",
+                "--instance",
+                str(inst_path),
+                "--algo",
+                "grasp",
+                "--k",
+                "2",
+                "--beta",
+                "0.10",
+                "--budget-time-ms",
+                "5000",
+                "--seed",
+                "42",
+                "--out",
+                str(out_json),
+                "--workdir",
+                str(workdir),
+            ]
+        )
+
+    cli_obj = json.loads(buf.getvalue())
+    assert cli_obj["algo"] == "grasp"
+    assert cli_obj["status"] == "ok"
+    assert out_json.exists()
+
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+    assert data["algo"] == "grasp"
+    assert data["seed"] == 42

--- a/tests/test_runner_grasp.py
+++ b/tests/test_runner_grasp.py
@@ -1,0 +1,58 @@
+import gzip
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+
+from hpc_framework.runner import run_one
+
+
+def _write_instance_edges(tmp_path: Path, n: int = 10) -> Path:
+    edges = [[i, i + 1] for i in range(n - 1)]
+    inst = {"instance_id": "toy", "num_nodes": n, "edges": edges}
+    ipath = tmp_path / "toy.json.gz"
+    with gzip.open(ipath, "wt", encoding="utf-8") as f:
+        json.dump(inst, f)
+    return ipath
+
+
+def test_runner_grasp_single_run_emits_schema_compatible_output(tmp_path: Path):
+    inst_path = _write_instance_edges(tmp_path, n=12)
+    out_json = tmp_path / "out_grasp.json"
+    workdir = tmp_path / "work"
+
+    run_one(
+        instance_path=inst_path,
+        algo="grasp",
+        k=3,
+        beta=0.10,
+        seed=42,
+        budget_time_ms=5000,
+        out_json=out_json,
+        workdir=workdir,
+        kahip_preset="fast",
+        log_level="info",
+    )
+
+    assert out_json.exists()
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+
+    assert data["algo"] == "grasp"
+    assert data["instance_id"] == "toy"
+    assert data["k"] == 3
+    assert data["beta"] == 0.10
+    assert data["seed"] == 42
+    assert data["status"] == "ok"
+    assert isinstance(data["elapsed_ms"], int)
+    assert data["elapsed_ms"] >= 0
+    assert Path(data["paths"]["workdir"]).exists()
+    assert Path(data["paths"]["graph_path"]).exists()
+    assert Path(data["paths"]["part_path"]).exists()
+    assert len(data["checkpoints"]) >= 1
+    assert data["checkpoints"][-1]["nfe"] >= 0
+    assert data["checkpoints"][-1]["cutsize_best"] == data["cutsize_best"]
+
+    schema_path = Path("specs/jsonschema/solver_run.schema.v1.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    errors = sorted(Draft7Validator(schema).iter_errors(data), key=lambda e: list(e.path))
+    assert errors == [], [f"{'.'.join(map(str, e.path)) or '<root>'}: {e.message}" for e in errors]


### PR DESCRIPTION
## Summary
- integrate canonical GRASP into `runner.py` single-run execution
- extend CLI single-run mode to accept `--algo grasp`
- add focused tests for GRASP runner output and CLI single-run execution

## Validation
- `poetry run pytest -q tests/test_grasp_scaffold.py tests/test_plan_runner_grasp.py tests/test_runner_grasp.py tests/test_cli_single_run_grasp.py tests/test_results_schema.py tests/test_runner_ils.py tests/test_runner_sa.py`
- `poetry run pytest -q`

## Scope boundary
- this PR completes GRASP support in the current repository surface
- TS remains out of scope
