### PR TITLE
feat: add canonical Tabu Search scaffold

### DIFF
--- a/src/heuristics/ts.py
+++ b/src/heuristics/ts.py
@@ -1,0 +1,192 @@
+"""Canonical Tabu Search scaffold for k-way graph partitioning.
+
+This module keeps TS local to the canonical GPP state representation. It does
+not yet extend the official runner or CLI surfaces. The goal is to validate a
+deterministic tabu-based local search kernel before wiring TS into the
+declarative execution flow.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+
+from gpp_core.operator import (
+    Block,
+    PartitionState,
+    Vertex,
+    apply_move,
+    eval_move_delta_cut,
+    is_move_feasible,
+)
+from heuristics.sa import SACheckpoint, build_initial_state
+
+
+@dataclass(frozen=True)
+class TSConfig:
+    """Configuration of the canonical TS scaffold."""
+
+    seed: int
+    budget_time_ms: int
+    max_steps: int = 10_000
+    min_tenure: int = 5
+    tenure_scale: float = 1.0
+    tenure_jitter: int = 4
+    checkpoint_every_nfe: int = 100
+    frequency_penalty: float = 0.01
+
+
+@dataclass(frozen=True)
+class TSResult:
+    """Structured result returned by the canonical TS scaffold."""
+
+    best_part_of: dict[Vertex, Block]
+    best_cutsize: int
+    elapsed_ms: int
+    nfe: int
+    checkpoints: list[SACheckpoint]
+    status: str
+
+
+def clone_state(state: PartitionState) -> PartitionState:
+    """Return a detached copy of a partition state."""
+    return PartitionState(
+        adj=state.adj,
+        part_of=dict(state.part_of),
+        block_size=dict(state.block_size),
+        k=state.k,
+        epsilon=state.epsilon,
+        cutsize=int(state.cutsize),
+        boundary=set(state.boundary),
+    )
+
+
+def _compute_tenure(n: int, config: TSConfig, rng: random.Random) -> int:
+    """Compute a short-term tabu tenure with mild random jitter."""
+    base = max(int(config.min_tenure), int(round(float(config.tenure_scale) * (n**0.5))))
+    jitter = rng.randint(0, max(0, int(config.tenure_jitter)))
+    return base + jitter
+
+
+def run_ts_partition(
+    adj: dict[Vertex, set[Vertex]],
+    *,
+    k: int,
+    epsilon: float,
+    config: TSConfig,
+) -> TSResult:
+    """Run a minimal deterministic TS kernel over the canonical GPP state."""
+    rng = random.Random(config.seed)
+    current = build_initial_state(adj, k=k, epsilon=epsilon, seed=config.seed)
+
+    best = clone_state(current)
+    best_cutsize = int(current.cutsize)
+
+    nfe = 0
+    step = 0
+    tabu_until: dict[tuple[Vertex, Block], int] = {}
+    move_frequency: dict[tuple[Vertex, Block], int] = {}
+    checkpoints: list[SACheckpoint] = [SACheckpoint(time_ms=0, cutsize_best=best_cutsize, nfe=0)]
+
+    t0 = time.perf_counter()
+    status = "ok"
+
+    while step < int(config.max_steps):
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        if elapsed_ms >= int(config.budget_time_ms):
+            status = "timeout"
+            break
+
+        vertices = list(current.boundary) if current.boundary else list(current.part_of.keys())
+        rng.shuffle(vertices)
+
+        best_move: tuple[float, int, int, Vertex, Block, Block] | None = None
+
+        for v in vertices:
+            source = current.part_of[v]
+            targets = list(range(current.k))
+            rng.shuffle(targets)
+
+            for target in targets:
+                if target == source:
+                    continue
+                if not is_move_feasible(current, v, target):
+                    continue
+
+                delta = eval_move_delta_cut(current, v, target)
+                nfe += 1
+
+                candidate_cut = int(current.cutsize + delta)
+                tabu_key = (v, target)
+                is_tabu = step < tabu_until.get(tabu_key, -1)
+                aspiration = candidate_cut < best_cutsize
+
+                if is_tabu and not aspiration:
+                    continue
+
+                freq = move_frequency.get((v, target), 0)
+                score = float(candidate_cut) + float(config.frequency_penalty) * float(freq)
+
+                candidate = (
+                    score,
+                    int(delta),
+                    len(current.adj[v]),
+                    int(v),
+                    int(target),
+                    int(source),
+                )
+
+                if best_move is None or candidate < best_move:
+                    best_move = candidate
+
+        if best_move is None:
+            break
+
+        _score, _delta, _deg, v_sel, target_sel, source_sel = best_move
+        apply_move(current, v_sel, target_sel)
+
+        move_frequency[(v_sel, target_sel)] = move_frequency.get((v_sel, target_sel), 0) + 1
+        tabu_until[(v_sel, source_sel)] = step + _compute_tenure(len(adj), config, rng)
+
+        if current.cutsize < best_cutsize:
+            best = clone_state(current)
+            best_cutsize = int(current.cutsize)
+
+        step += 1
+
+        if nfe > 0 and nfe % int(config.checkpoint_every_nfe) == 0:
+            checkpoints.append(
+                SACheckpoint(
+                    time_ms=int((time.perf_counter() - t0) * 1000),
+                    cutsize_best=best_cutsize,
+                    nfe=nfe,
+                )
+            )
+
+    elapsed_ms = int((time.perf_counter() - t0) * 1000)
+    if checkpoints[-1].nfe != nfe or checkpoints[-1].cutsize_best != best_cutsize:
+        checkpoints.append(
+            SACheckpoint(
+                time_ms=elapsed_ms,
+                cutsize_best=best_cutsize,
+                nfe=nfe,
+            )
+        )
+
+    return TSResult(
+        best_part_of=dict(best.part_of),
+        best_cutsize=best_cutsize,
+        elapsed_ms=elapsed_ms,
+        nfe=nfe,
+        checkpoints=checkpoints,
+        status=status,
+    )
+
+
+__all__ = [
+    "TSConfig",
+    "TSResult",
+    "clone_state",
+    "run_ts_partition",
+]

--- a/tests/test_ts_scaffold.py
+++ b/tests/test_ts_scaffold.py
@@ -1,0 +1,99 @@
+"""Tests for the canonical TS scaffold."""
+
+from __future__ import annotations
+
+from gpp_core.operator import compute_cutsize_naive
+from heuristics.sa import build_initial_state
+from heuristics.ts import TSConfig, run_ts_partition
+
+
+def _path_adj(n: int) -> dict[int, set[int]]:
+    adj = {i: set() for i in range(n)}
+    for i in range(n - 1):
+        adj[i].add(i + 1)
+        adj[i + 1].add(i)
+    return adj
+
+
+def test_run_ts_partition_returns_valid_anytime_result():
+    adj = _path_adj(12)
+    initial = build_initial_state(adj, k=3, epsilon=0.10, seed=7)
+
+    result = run_ts_partition(
+        adj,
+        k=3,
+        epsilon=0.10,
+        config=TSConfig(
+            seed=7,
+            budget_time_ms=200,
+            max_steps=500,
+            min_tenure=3,
+            tenure_scale=1.0,
+            tenure_jitter=2,
+            checkpoint_every_nfe=10,
+            frequency_penalty=0.01,
+        ),
+    )
+
+    assert result.status in {"ok", "timeout"}
+    assert result.best_cutsize <= initial.cutsize
+    assert result.best_cutsize == compute_cutsize_naive(adj, result.best_part_of)
+    assert result.nfe >= 0
+    assert len(result.checkpoints) >= 1
+
+    times = [cp.time_ms for cp in result.checkpoints]
+    nfes = [cp.nfe for cp in result.checkpoints]
+
+    assert times == sorted(times)
+    assert nfes == sorted(nfes)
+    assert result.checkpoints[-1].cutsize_best == result.best_cutsize
+    assert result.checkpoints[-1].nfe == result.nfe
+
+
+def test_run_ts_partition_is_deterministic_with_fixed_seed_and_steps():
+    adj = _path_adj(10)
+    cfg = TSConfig(
+        seed=123,
+        budget_time_ms=10_000,
+        max_steps=50,
+        min_tenure=3,
+        tenure_scale=1.0,
+        tenure_jitter=2,
+        checkpoint_every_nfe=5,
+        frequency_penalty=0.01,
+    )
+
+    r1 = run_ts_partition(adj, k=2, epsilon=0.10, config=cfg)
+    r2 = run_ts_partition(adj, k=2, epsilon=0.10, config=cfg)
+
+    assert r1.best_part_of == r2.best_part_of
+    assert r1.best_cutsize == r2.best_cutsize
+    assert r1.nfe == r2.nfe
+
+
+def test_run_ts_partition_preserves_balance_contract():
+    adj = _path_adj(14)
+
+    result = run_ts_partition(
+        adj,
+        k=2,
+        epsilon=0.10,
+        config=TSConfig(
+            seed=19,
+            budget_time_ms=200,
+            max_steps=100,
+            min_tenure=3,
+            tenure_scale=1.0,
+            tenure_jitter=2,
+            checkpoint_every_nfe=10,
+            frequency_penalty=0.01,
+        ),
+    )
+
+    block_counts: dict[int, int] = {}
+    for block in result.best_part_of.values():
+        block_counts[block] = block_counts.get(block, 0) + 1
+
+    n = len(adj)
+    max_allowed = int((1.0 + 0.10) * (n / 2)) + 1
+    assert max(block_counts.values()) <= max_allowed


### PR DESCRIPTION
## Summary
- add a canonical Tabu Search scaffold over `PartitionState`
- keep the scope intentionally local, without wiring TS into the official runner yet
- add focused tests for deterministic seeded execution, balance preservation, and anytime checkpoint behavior

## Validation
- `poetry run pytest -q tests/test_ts_scaffold.py tests/test_grasp_scaffold.py tests/test_ils_scaffold.py tests/test_sa_scaffold.py tests/test_operator.py`
- `poetry run pytest -q`

## Notes
- this PR validates only the canonical TS search kernel
- runner/plan/CLI integration will come in later PRs after the search core is frozen
