### PR TITLE
docs: switch mkdocs theme to dracula

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          pip install mkdocs mkdocs-material "mkdocstrings[python]" mkdocs-autorefs mkdocs-minify-plugin
+          pip install mkdocs mkdocs-dracula-theme "mkdocstrings[python]" mkdocs-autorefs mkdocs-minify-plugin
 
       - name: Build docs (strict)
         run: python -m mkdocs build --strict --site-dir /tmp/forja-mkdocs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Infraestrutura experimental auditável para comparação justa entre solvers multilevel e meta-heurísticas sob um protocolo congelado de `fair(time)`.
 
 [![CI](https://github.com/LBSL98/Heuristic_Benchmarking_Framework/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/LBSL98/Heuristic_Benchmarking_Framework/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/badge/docs-online-0A7BBB?logo=materialformkdocs&logoColor=white)](https://lbsl98.github.io/Heuristic_Benchmarking_Framework/)
+[![Docs](https://img.shields.io/badge/docs-online-6272A4?logo=readthedocs&logoColor=white)](https://lbsl98.github.io/Heuristic_Benchmarking_Framework/)
 [![Release](https://img.shields.io/badge/release-benchmark--main--ready--2026--04--27-6f42c1)](https://github.com/LBSL98/Heuristic_Benchmarking_Framework/releases/tag/benchmark-main-ready-2026-04-27)
 ![Python](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,69 +1,62 @@
 site_name: FORJA / MPP Docs
-site_description: Reproducible benchmarking framework for fair graph partitioning comparisons.
+site_description: Reproducible benchmarking framework for fair graph partitioning
+  comparisons.
 site_url: https://lbsl98.github.io/Heuristic_Benchmarking_Framework/
 repo_url: https://github.com/LBSL98/Heuristic_Benchmarking_Framework
 repo_name: LBSL98/Heuristic_Benchmarking_Framework
 edit_uri: edit/main/docs/
 theme:
-  name: material
-  features:
-    - navigation.sections
-    - navigation.top
-    - search.highlight
-    - search.suggest
-    - content.code.copy
-
+  name: dracula
 markdown_extensions:
-  - admonition
-  - attr_list
-  - tables
-  - toc:
-      permalink: true
-
+- admonition
+- attr_list
+- tables
+- toc:
+    permalink: true
 nav:
-  - Home: index.md
-  - Active Contract:
-      - Current Benchmark Contract: protocol/current_benchmark_contract.md
-      - Reproducibility Checklist: specs/reproducibility_checklist.md
-      - Testing Guide: testing/TESTING.md
-      - CI: testing/CI.md
-      - Traceability: testing/TRACEABILITY.md
-      - Test Cases:
-          - TC_001 Modularity Gate: testing/testcases/TC_001_modularity_gate.md
-          - TC_002 CV Ceiling: testing/testcases/TC_002_cv_ceiling.md
-          - TC_003 Schema Freeze: testing/testcases/TC_003_schema_freeze.md
-          - TC_004 CLI Examples: testing/testcases/TC_004_cli_examples.md
-          - TC_005 Perf Smoke: testing/testcases/TC_005_perf_smoke.md
-  - API:
-      - Generator CLI: api/generator_cli.md
-      - HPC Framework CLI: api/hpc_framework_cli.md
-      - Heuristics (Greedy): api/heuristics_greedy.md
-      - SSH Orchestrator: api/orchestrator_ssh_executor.md
-  - Reports:
-      - Instance Generator: reports/01_instance_generator.md
-  - Legacy / Quarantine:
-      - Archived Protocol v3.1.1: protocol/proto_v3.1.1.md
-      - Archived Architecture Overview: 00_architectural_overview.md
-      - Archived Workflow Plan: 01_project_plan_and_workflow.md
-      - Archived Campaign Report: reports/02_experimental_campaign.md
-      - Archived Baseline v1.0: specs/baseline_evolutive_v1.md
-      - Archived ADR 003: decisions/003_metodologia_gerador_e_analise.md
-      - ADR 001 Language Choice: decisions/001_choice_heuristic_language.md
-      - ADR 004 Testing & CI: decisions/004_testing_and_ci.md
-
+- Home: index.md
+- Active Contract:
+  - Current Benchmark Contract: protocol/current_benchmark_contract.md
+  - Reproducibility Checklist: specs/reproducibility_checklist.md
+  - Testing Guide: testing/TESTING.md
+  - CI: testing/CI.md
+  - Traceability: testing/TRACEABILITY.md
+  - Test Cases:
+    - TC_001 Modularity Gate: testing/testcases/TC_001_modularity_gate.md
+    - TC_002 CV Ceiling: testing/testcases/TC_002_cv_ceiling.md
+    - TC_003 Schema Freeze: testing/testcases/TC_003_schema_freeze.md
+    - TC_004 CLI Examples: testing/testcases/TC_004_cli_examples.md
+    - TC_005 Perf Smoke: testing/testcases/TC_005_perf_smoke.md
+- API:
+  - Generator CLI: api/generator_cli.md
+  - HPC Framework CLI: api/hpc_framework_cli.md
+  - Heuristics (Greedy): api/heuristics_greedy.md
+  - SSH Orchestrator: api/orchestrator_ssh_executor.md
+- Reports:
+  - Instance Generator: reports/01_instance_generator.md
+- Legacy / Quarantine:
+  - Archived Protocol v3.1.1: protocol/proto_v3.1.1.md
+  - Archived Architecture Overview: 00_architectural_overview.md
+  - Archived Workflow Plan: 01_project_plan_and_workflow.md
+  - Archived Campaign Report: reports/02_experimental_campaign.md
+  - Archived Baseline v1.0: specs/baseline_evolutive_v1.md
+  - Archived ADR 003: decisions/003_metodologia_gerador_e_analise.md
+  - ADR 001 Language Choice: decisions/001_choice_heuristic_language.md
+  - ADR 004 Testing & CI: decisions/004_testing_and_ci.md
 plugins:
-  - search
-  - autorefs
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: [src]
-          options:
-            docstring_style: google
-            docstring_section_style: table
-            show_source: false
-            show_signature: true
-            separate_signature: true
-            merge_init_into_class: true
-  - minify:
-      minify_html: true
+- search
+- autorefs
+- mkdocstrings:
+    handlers:
+      python:
+        paths:
+        - src
+        options:
+          docstring_style: google
+          docstring_section_style: table
+          show_source: false
+          show_signature: true
+          separate_signature: true
+          merge_init_into_class: true
+- minify:
+    minify_html: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ black               = "^24.10.0"
 mypy                = "^1.17.1"
 interrogate         = "^1.7.0"
 mkdocs              = "^1.6.1"
-mkdocs-material     = "^9.5.49"
+mkdocs-dracula-theme = "^1.0.9"
 mkdocstrings        = { version = "^0.30.0" }
 mkdocstrings-python = { version = "^1.8.2" }
 griffe              = "^1.5.4"
@@ -64,7 +64,7 @@ mkdocs-minify-plugin = "^0.8.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.1"
-mkdocs-material = "^9.6.19"
+mkdocs-dracula-theme = "^1.0.9"
 mkdocstrings = { extras = ["python"], version = "^0.30.0" }
 mkdocs-autorefs = "^1.4.3"
 mkdocs-minify-plugin = "^0.8.0"


### PR DESCRIPTION
## Summary
- switch the documentation theme from Material to Dracula
- replace Material-specific docs dependency with `mkdocs-dracula-theme`
- update the docs publishing workflow to install the Dracula theme
- keep the current documentation navigation and plugin surface intact

## Validation
- `python -m mkdocs build --strict --site-dir /tmp/forja-mkdocs`

## Notes
- this PR is a visual/style migration for the documentation surface
- it does not start the benchmark campaign
