### PR TITLE
docs: add pt/en bilingual scaffold

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          pip install mkdocs mkdocs-dracula-theme "mkdocstrings[python]" mkdocs-autorefs mkdocs-minify-plugin
+          pip install mkdocs mkdocs-dracula-theme mkdocs-static-i18n "mkdocstrings[python]" mkdocs-autorefs mkdocs-minify-plugin
 
       - name: Build docs (strict)
         run: python -m mkdocs build --strict --site-dir /tmp/forja-mkdocs

--- a/docs/getting_started.en.md
+++ b/docs/getting_started.en.md
@@ -1,0 +1,50 @@
+# Quickstart
+
+## 1. Requirements
+
+- Linux / Ubuntu 22.04+
+- Python 3.11+
+- `gpmetis` available in `PATH`
+- `kaffpa` optional for KaHIP runs
+
+## 2. Local install
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3.11 python3.11-venv python3-pip metis
+
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install .
+```
+
+## 3. Local smoke test
+
+```bash
+OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 \
+MKL_NUM_THREADS=1 \
+pytest -q
+```
+
+## 4. Local docs build
+
+```bash
+python -m mkdocs build --strict --site-dir /tmp/forja-mkdocs
+```
+
+## 5. Read this before real runs
+
+Before launching real campaigns, read:
+
+- [Current benchmark contract](protocol/current_benchmark_contract.md)
+- [Reproducibility checklist](specs/reproducibility_checklist.md)
+
+## 6. First useful command
+
+```bash
+./scripts/run_phase_1.sh
+```
+
+At this stage, some deeper reference pages may still fall back to Portuguese until reviewed English versions are added.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,50 @@
+# Início rápido
+
+## 1. Pré-requisitos
+
+- Linux / Ubuntu 22.04+
+- Python 3.11+
+- `gpmetis` disponível no `PATH`
+- `kaffpa` opcional para rodadas com KaHIP
+
+## 2. Instalação local
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3.11 python3.11-venv python3-pip metis
+
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install .
+```
+
+## 3. Smoke local
+
+```bash
+OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 \
+MKL_NUM_THREADS=1 \
+pytest -q
+```
+
+## 4. Build local da documentação
+
+```bash
+python -m mkdocs build --strict --site-dir /tmp/forja-mkdocs
+```
+
+## 5. Primeiro ponto de leitura
+
+Antes de rodar campanhas reais, leia:
+
+- [Contrato atual do benchmark](protocol/current_benchmark_contract.md)
+- [Checklist de reprodutibilidade](specs/reproducibility_checklist.md)
+
+## 6. Primeiro comando útil
+
+```bash
+./scripts/run_phase_1.sh
+```
+
+Use esse caminho apenas quando o seu ambiente local já estiver consistente com o protocolo ativo do repositório.

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -45,9 +45,5 @@ Go to **Engineering**.
 
 Go to **Archive**.
 
-## Languages
-
-- [Português](../)
-- [English](./)
 
 This English layer is being expanded incrementally. When a reviewed English page is not available yet, the site falls back to the default Portuguese page.

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,0 +1,53 @@
+# FORJA
+
+> Auditable framework for reproducible graph partitioning benchmarking under a frozen `fair(time)` protocol.
+
+## What this site is for
+
+This site is the public entry point to FORJA's technical documentation. It organizes the repository material into four practical layers:
+
+- getting started;
+- reading the active benchmark contract;
+- navigating framework engineering material;
+- accessing archived historical material kept for traceability.
+
+## Current project status
+
+In the current public repository state:
+
+- the benchmark pilot has been executed and approved;
+- the active benchmark contract is frozen;
+- the main campaign is methodologically admissible;
+- the main campaign has not started yet.
+
+## Start here
+
+- [Quickstart](getting_started.md)
+- [Current benchmark contract](protocol/current_benchmark_contract.md)
+- [Reproducibility checklist](specs/reproducibility_checklist.md)
+- [Testing guide](testing/TESTING.md)
+
+## Navigate by goal
+
+### I want to execute or validate the benchmark
+
+Go to **Get Started**, **Benchmark**, and **Engineering**.
+
+### I want the active methodological contract
+
+Go to **Benchmark**.
+
+### I want testing, CI, and traceability details
+
+Go to **Engineering**.
+
+### I want archived historical material
+
+Go to **Archive**.
+
+## Languages
+
+- [Português](../)
+- [English](./)
+
+This English layer is being expanded incrementally. When a reviewed English page is not available yet, the site falls back to the default Portuguese page.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,31 +1,53 @@
-# FORJA / MPP Docs
+# FORJA
 
-Esta documentação foi reorganizada para separar o **contrato ativo** do repositório dos materiais
-preservados apenas por **rastreabilidade histórica**.
+> Framework auditável para benchmarking reprodutível de particionamento de grafos sob um protocolo congelado de `fair(time)`.
 
-## Use como fonte ativa
+## O que é este site
 
-- `protocol/current_benchmark_contract.md`
-- `specs/reproducibility_checklist.md`
-- `testing/TESTING.md`
-- `testing/CI.md`
-- `testing/TRACEABILITY.md`
+Este site é a porta de entrada da documentação técnica do FORJA. Ele organiza o material do repositório em quatro camadas práticas:
 
-Essas páginas refletem o estado canônico atual do benchmark no repositório:
+- começar a usar;
+- consultar o contrato ativo do benchmark;
+- navegar a engenharia do framework;
+- acessar material histórico preservado por rastreabilidade.
 
-- portfólio oficial da tese = `SA`, `TS`, `ILS`, `GRASP`, `METIS`, `KaHIP`
-- `greedy` apenas como fluxo exploratório
-- comparação universal por wall-clock / `fair(time)`
-- contrato serializado com `elapsed_ms` e `checkpoints[].time_ms`
-- KaHIP 3.17 como narrativa experimental oficial, sem inferir a verdade experimental da árvore vendorizada `./KaHIP`
+## Estado atual do projeto
 
-## Legado / quarentena
+No estado público atual do repositório:
 
-Algumas páginas antigas foram preservadas para auditoria, mas não devem orientar o fluxo atual.
-Elas aparecem explicitamente sob a seção **Legacy / Quarantine** na navegação do site.
+- o piloto benchmarkado foi executado e aprovado;
+- o contrato ativo do benchmark está congelado;
+- a campanha principal está metodologicamente admissível;
+- a campanha principal ainda não foi iniciada.
 
-Quando houver conflito entre documentação legada e contrato ativo:
+## Comece aqui
 
-1. prevalecem os arquivos canônicos em `decisions/` e `specs/`;
-2. prevalece a página `protocol/current_benchmark_contract.md` dentro deste site;
-3. materiais legados ficam preservados apenas como trilha histórica.
+- [Início rápido](getting_started.md)
+- [Contrato atual do benchmark](protocol/current_benchmark_contract.md)
+- [Checklist de reprodutibilidade](specs/reproducibility_checklist.md)
+- [Guia de testes](testing/TESTING.md)
+
+## Navegue por objetivo
+
+### Quero executar ou validar o benchmark
+
+Vá para **Comece Aqui**, **Benchmark** e **Engenharia**.
+
+### Quero consultar o contrato metodológico
+
+Vá para **Benchmark**.
+
+### Quero entender testes, CI e rastreabilidade
+
+Vá para **Engenharia**.
+
+### Quero ver materiais históricos preservados
+
+Vá para **Arquivo**.
+
+## Idiomas
+
+- [Português](./)
+- [English](en/)
+
+A versão em inglês será expandida gradualmente. Quando uma página ainda não tiver tradução revisada, o site poderá usar a versão padrão em português como fallback.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,9 +45,5 @@ Vá para **Engenharia**.
 
 Vá para **Arquivo**.
 
-## Idiomas
-
-- [Português](./)
-- [English](en/)
 
 A versão em inglês será expandida gradualmente. Quando uma página ainda não tiver tradução revisada, o site poderá usar a versão padrão em português como fallback.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,5 @@
 site_name: FORJA / MPP Docs
-site_description: Reproducible benchmarking framework for fair graph partitioning
-  comparisons.
+site_description: Reproducible benchmarking framework for fair graph partitioning comparisons.
 site_url: https://lbsl98.github.io/Heuristic_Benchmarking_Framework/
 repo_url: https://github.com/LBSL98/Heuristic_Benchmarking_Framework
 repo_name: LBSL98/Heuristic_Benchmarking_Framework
@@ -15,9 +14,12 @@ markdown_extensions:
     permalink: true
 nav:
 - Home: index.md
-- Active Contract:
+- Get Started:
+  - Quickstart: getting_started.md
+- Benchmark:
   - Current Benchmark Contract: protocol/current_benchmark_contract.md
   - Reproducibility Checklist: specs/reproducibility_checklist.md
+- Engineering:
   - Testing Guide: testing/TESTING.md
   - CI: testing/CI.md
   - Traceability: testing/TRACEABILITY.md
@@ -34,7 +36,7 @@ nav:
   - SSH Orchestrator: api/orchestrator_ssh_executor.md
 - Reports:
   - Instance Generator: reports/01_instance_generator.md
-- Legacy / Quarantine:
+- Archive:
   - Archived Protocol v3.1.1: protocol/proto_v3.1.1.md
   - Archived Architecture Overview: 00_architectural_overview.md
   - Archived Workflow Plan: 01_project_plan_and_workflow.md
@@ -43,7 +45,42 @@ nav:
   - Archived ADR 003: decisions/003_metodologia_gerador_e_analise.md
   - ADR 001 Language Choice: decisions/001_choice_heuristic_language.md
   - ADR 004 Testing & CI: decisions/004_testing_and_ci.md
+- Language:
+  - Português: https://lbsl98.github.io/Heuristic_Benchmarking_Framework/
+  - English: https://lbsl98.github.io/Heuristic_Benchmarking_Framework/en/
 plugins:
+- i18n:
+    docs_structure: suffix
+    fallback_to_default: true
+    languages:
+    - locale: pt
+      name: Português
+      default: true
+      build: true
+      nav_translations:
+        Home: Início
+        Get Started: Comece Aqui
+        Quickstart: Início rápido
+        Benchmark: Benchmark
+        Engineering: Engenharia
+        Reports: Relatórios
+        Archive: Arquivo
+        Language: Idioma
+        Current Benchmark Contract: Contrato Atual do Benchmark
+        Reproducibility Checklist: Checklist de Reprodutibilidade
+        Testing Guide: Guia de Testes
+        Traceability: Rastreabilidade
+        Test Cases: Casos de Teste
+        Instance Generator: Gerador de Instâncias
+        Archived Protocol v3.1.1: Protocolo Arquivado v3.1.1
+        Archived Architecture Overview: Visão Arquitetural Arquivada
+        Archived Workflow Plan: Plano de Trabalho Arquivado
+        Archived Campaign Report: Relatório de Campanha Arquivado
+        Archived Baseline v1.0: Baseline Arquivada v1.0
+        Archived ADR 003: ADR 003 Arquivada
+    - locale: en
+      name: English
+      build: true
 - search
 - autorefs
 - mkdocstrings:

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,41 +21,6 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
-name = "babel"
-version = "2.17.0"
-description = "Internationalization utilities"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev", "docs"]
-files = [
-    {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
-    {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
-]
-
-[package.extras]
-dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
-
-[[package]]
-name = "backrefs"
-version = "5.9"
-description = "A wrapper around re and regex that adds additional back references."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev", "docs"]
-files = [
-    {file = "backrefs-5.9-py310-none-any.whl", hash = "sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f"},
-    {file = "backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf"},
-    {file = "backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa"},
-    {file = "backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b"},
-    {file = "backrefs-5.9-py314-none-any.whl", hash = "sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9"},
-    {file = "backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60"},
-    {file = "backrefs-5.9.tar.gz", hash = "sha256:808548cb708d66b82ee231f962cb36faaf4f2baab032f2fbb783e9c2fdddaa59"},
-]
-
-[package.extras]
-extras = ["regex"]
-
-[[package]]
 name = "bcrypt"
 version = "4.3.0"
 description = "Modern password hashing for your software and your servers"
@@ -166,18 +131,6 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
-name = "certifi"
-version = "2025.8.3"
-description = "Python package for providing Mozilla's CA Bundle."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev", "docs"]
-files = [
-    {file = "certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"},
-    {file = "certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407"},
-]
-
-[[package]]
 name = "cffi"
 version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
@@ -284,95 +237,6 @@ groups = ["dev"]
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.3"
-description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev", "docs"]
-files = [
-    {file = "charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07a0eae9e2787b586e129fdcbe1af6997f8d0e5abaa0bc98c0e20e124d67e601"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:74d77e25adda8581ffc1c720f1c81ca082921329452eba58b16233ab1842141c"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0e909868420b7049dafd3a31d45125b31143eec59235311fc4c57ea26a4acd2"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c6f162aabe9a91a309510d74eeb6507fab5fff92337a15acbe77753d88d9dcf0"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4ca4c094de7771a98d7fbd67d9e5dbf1eb73efa4f744a730437d8a3a5cf994f0"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:02425242e96bcf29a49711b0ca9f37e451da7c70562bc10e8ed992a5a7a25cc0"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:78deba4d8f9590fe4dae384aeff04082510a709957e968753ff3c48399f6f92a"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-win32.whl", hash = "sha256:d79c198e27580c8e958906f803e63cddb77653731be08851c7df0b1a14a8fc0f"},
-    {file = "charset_normalizer-3.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c6e490913a46fa054e03699c70019ab869e990270597018cef1d8562132c2669"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b256ee2e749283ef3ddcff51a675ff43798d92d746d1a6e4631bf8c707d22d0b"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13faeacfe61784e2559e690fc53fa4c5ae97c6fcedb8eb6fb8d0a15b475d2c64"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00237675befef519d9af72169d8604a067d92755e84fe76492fef5441db05b91"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:585f3b2a80fbd26b048a0be90c5aae8f06605d3c92615911c3a2b03a8a3b796f"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e78314bdc32fa80696f72fa16dc61168fda4d6a0c014e0380f9d02f0e5d8a07"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:96b2b3d1a83ad55310de8c7b4a2d04d9277d5591f40761274856635acc5fcb30"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:939578d9d8fd4299220161fdd76e86c6a251987476f5243e8864a7844476ba14"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fd10de089bcdcd1be95a2f73dbe6254798ec1bda9f450d5828c96f93e2536b9c"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e8ac75d72fa3775e0b7cb7e4629cec13b7514d928d15ef8ea06bca03ef01cae"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-win32.whl", hash = "sha256:6cf8fd4c04756b6b60146d98cd8a77d0cdae0e1ca20329da2ac85eed779b6849"},
-    {file = "charset_normalizer-3.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:31a9a6f775f9bcd865d88ee350f0ffb0e25936a7f930ca98995c05abf1faf21c"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37"},
-    {file = "charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce"},
-    {file = "charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce"},
-    {file = "charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0f2be7e0cf7754b9a30eb01f4295cc3d4358a479843b31f328afd210e2c7598c"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c60e092517a73c632ec38e290eba714e9627abe9d301c8c8a12ec32c314a2a4b"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:252098c8c7a873e17dd696ed98bbe91dbacd571da4b87df3736768efa7a792e4"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3653fad4fe3ed447a596ae8638b437f827234f01a8cd801842e43f3d0a6b281b"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8999f965f922ae054125286faf9f11bc6932184b93011d138925a1773830bbe9"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d95bfb53c211b57198bb91c46dd5a2d8018b3af446583aab40074bf7988401cb"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:5b413b0b1bfd94dbf4023ad6945889f374cd24e3f62de58d6bb102c4d9ae534a"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:b5e3b2d152e74e100a9e9573837aba24aab611d39428ded46f4e4022ea7d1942"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a2d08ac246bb48479170408d6c19f6385fa743e7157d716e144cad849b2dd94b"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-win32.whl", hash = "sha256:ec557499516fc90fd374bf2e32349a2887a876fbf162c160e3c01b6849eaf557"},
-    {file = "charset_normalizer-3.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:5d8d01eac18c423815ed4f4a2ec3b439d654e55ee4ad610e153cf02faf67ea40"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-win32.whl", hash = "sha256:16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432"},
-    {file = "charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca"},
-    {file = "charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a"},
-    {file = "charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"},
 ]
 
 [[package]]
@@ -710,21 +574,6 @@ files = [
 license = ["ukkonen"]
 
 [[package]]
-name = "idna"
-version = "3.10"
-description = "Internationalized Domain Names in Applications (IDNA)"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev", "docs"]
-files = [
-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
-]
-
-[package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -987,6 +836,21 @@ markupsafe = ">=2.0.1"
 mkdocs = ">=1.1"
 
 [[package]]
+name = "mkdocs-dracula-theme"
+version = "1.0.9"
+description = "Dark theme for Mkdocs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev", "docs"]
+files = [
+    {file = "mkdocs_dracula_theme-1.0.9-py3-none-any.whl", hash = "sha256:f7d6ad0521041f49e32d454b1d8158695bb833e53d679a12f5dd7cef13738f07"},
+    {file = "mkdocs_dracula_theme-1.0.9.tar.gz", hash = "sha256:8596670e8a8f72c27b89026bfb1885424ecee5d54130a617e651e27920338e21"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.6.1,<2.0.0"
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 description = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
@@ -1002,49 +866,6 @@ files = [
 mergedeep = ">=1.3.4"
 platformdirs = ">=2.2.0"
 pyyaml = ">=5.1"
-
-[[package]]
-name = "mkdocs-material"
-version = "9.6.19"
-description = "Documentation that simply works"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev", "docs"]
-files = [
-    {file = "mkdocs_material-9.6.19-py3-none-any.whl", hash = "sha256:7492d2ac81952a467ca8a10cac915d6ea5c22876932f44b5a0f4f8e7d68ac06f"},
-    {file = "mkdocs_material-9.6.19.tar.gz", hash = "sha256:80e7b3f9acabfee9b1f68bd12c26e59c865b3d5bbfb505fd1344e970db02c4aa"},
-]
-
-[package.dependencies]
-babel = ">=2.10,<3.0"
-backrefs = ">=5.7.post1,<6.0"
-click = "<8.2.2"
-colorama = ">=0.4,<1.0"
-jinja2 = ">=3.1,<4.0"
-markdown = ">=3.2,<4.0"
-mkdocs = ">=1.6,<2.0"
-mkdocs-material-extensions = ">=1.3,<2.0"
-paginate = ">=0.5,<1.0"
-pygments = ">=2.16,<3.0"
-pymdown-extensions = ">=10.2,<11.0"
-requests = ">=2.26,<3.0"
-
-[package.extras]
-git = ["mkdocs-git-committers-plugin-2 (>=1.1,<3)", "mkdocs-git-revision-date-localized-plugin (>=1.2.4,<2.0)"]
-imaging = ["cairosvg (>=2.6,<3.0)", "pillow (>=10.2,<12.0)"]
-recommended = ["mkdocs-minify-plugin (>=0.7,<1.0)", "mkdocs-redirects (>=1.2,<2.0)", "mkdocs-rss-plugin (>=1.6,<2.0)"]
-
-[[package]]
-name = "mkdocs-material-extensions"
-version = "1.3.1"
-description = "Extension pack for Python Markdown and MkDocs Material."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev", "docs"]
-files = [
-    {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
-    {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
-]
 
 [[package]]
 name = "mkdocs-minify-plugin"
@@ -1063,6 +884,24 @@ csscompressor = ">=0.9.5"
 htmlmin2 = ">=0.1.13"
 jsmin = ">=3.0.1"
 mkdocs = ">=1.4.1"
+
+[[package]]
+name = "mkdocs-static-i18n"
+version = "1.3.1"
+description = "MkDocs i18n plugin using static translation markdown files"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev", "docs"]
+files = [
+    {file = "mkdocs_static_i18n-1.3.1-py3-none-any.whl", hash = "sha256:4036e24795a150c9c4d4b001ed24a43aec01335f76188dbe5a5d8fb4a27eba65"},
+    {file = "mkdocs_static_i18n-1.3.1.tar.gz", hash = "sha256:a6125ea7db6cc1a900d76a967f262535af09831160a93c56d7f0d522a79b5faf"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.5.2"
+
+[package.extras]
+material = ["mkdocs-material (<9.7.2)"]
 
 [[package]]
 name = "mkdocstrings"
@@ -1309,22 +1148,6 @@ files = [
 ]
 
 [[package]]
-name = "paginate"
-version = "0.5.7"
-description = "Divides large result sets into pages for easier browsing"
-optional = false
-python-versions = "*"
-groups = ["dev", "docs"]
-files = [
-    {file = "paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591"},
-    {file = "paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945"},
-]
-
-[package.extras]
-dev = ["pytest", "tox"]
-lint = ["black"]
-
-[[package]]
 name = "pandas"
 version = "2.3.2"
 description = "Powerful data structures for data analysis, time series, and statistics"
@@ -1526,7 +1349,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -1763,28 +1586,6 @@ files = [
 attrs = ">=22.2.0"
 rpds-py = ">=0.7.0"
 typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
-
-[[package]]
-name = "requests"
-version = "2.32.5"
-description = "Python HTTP for Humans."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev", "docs"]
-files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
-]
-
-[package.dependencies]
-certifi = ">=2017.4.17"
-charset_normalizer = ">=2,<4"
-idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
-
-[package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rpds-py"
@@ -2127,24 +1928,6 @@ files = [
 ]
 
 [[package]]
-name = "urllib3"
-version = "2.5.0"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev", "docs"]
-files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
-]
-
-[package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
-h2 = ["h2 (>=4,<5)"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
 name = "virtualenv"
 version = "20.34.0"
 description = "Virtual Python Environment builder"
@@ -2305,4 +2088,4 @@ metrics = ["tqdm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "a69b5c598369dbaef400bcacc9e2d48fc30451fbbceb988ec985bbec9bb89923"
+content-hash = "d3521079c4693dbe361dc70b93fe821a3b713f1a2c5840667511cf33e1699fe5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ mypy                = "^1.17.1"
 interrogate         = "^1.7.0"
 mkdocs              = "^1.6.1"
 mkdocs-dracula-theme = "^1.0.9"
+mkdocs-static-i18n = "^1.3.1"
 mkdocstrings        = { version = "^0.30.0" }
 mkdocstrings-python = { version = "^1.8.2" }
 griffe              = "^1.5.4"
@@ -65,6 +66,7 @@ mkdocs-minify-plugin = "^0.8.0"
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.1"
 mkdocs-dracula-theme = "^1.0.9"
+mkdocs-static-i18n = "^1.3.1"
 mkdocstrings = { extras = ["python"], version = "^0.30.0" }
 mkdocs-autorefs = "^1.4.3"
 mkdocs-minify-plugin = "^0.8.0"


### PR DESCRIPTION
## Summary

* add a bilingual documentation scaffold using `mkdocs-static-i18n`
* keep Portuguese as the default language at the site root and expose English under `/en/`
* improve the landing page information architecture and add bilingual quickstart pages
* preserve deep reference coverage by falling back to the default Portuguese pages when English translations are not available yet
* refresh `poetry.lock` for the new documentation dependency

## Validation

* `poetry check`
* `python -m mkdocs build --strict --site-dir /tmp/forja-mkdocs`

## Notes

* this PR introduces multilingual documentation structure without starting the benchmark campaign
* it keeps the Dracula theme and uses explicit language links in navigation
