### PR TITLE
configs: align main benchmark plans with canonical seed and output policy

### DIFF
--- a/configs/plan_phase_1_baselines.yaml
+++ b/configs/plan_phase_1_baselines.yaml
@@ -1,8 +1,9 @@
 schema: forja-exp-v1
 experiment_id: tcc-phase1-baselines
-description: >
-  Official phase-1 baseline campaign for the canonical thesis portfolio.
+description: 'Official phase-1 baseline campaign for the canonical thesis portfolio.
   This plan contains only METIS and KaHIP under the fair(time) protocol.
+
+  '
 solvers:
   metis:
     enabled: true
@@ -29,19 +30,25 @@ solvers:
   ts:
     enabled: false
 rng:
-  seeds: [42]
+  seeds:
+  - 42
 instances:
   base_dir: data/instances/synthetic
   include:
-    - n2000_p50.json.gz
-    - modnull_n3000_p50.json.gz
-    - modnull_n3500_p40.json.gz
-    - mix_betas_n3000_p35_cv045.json.gz
-    - n4000_cv_high.json.gz
-    - n5000_cv_low.json.gz
-    - wilson_tree_n10000.json.gz
-    - n2000_dense_fast.json.gz
-  manifest_out: data/results_raw/manifest_index.csv
-  fields: [filename, n, m, density, cv_degree]
+  - n2000_p50.json.gz
+  - modnull_n3000_p50.json.gz
+  - modnull_n3500_p40.json.gz
+  - mix_betas_n3000_p35_cv045.json.gz
+  - n4000_cv_high.json.gz
+  - n5000_cv_low.json.gz
+  - wilson_tree_n10000.json.gz
+  - n2000_dense_fast.json.gz
+  manifest_out: data/results_raw/main_baselines/manifest_index.csv
+  fields:
+  - filename
+  - n
+  - m
+  - density
+  - cv_degree
 output:
-  raw_dir: data/results_raw
+  raw_dir: data/results_raw/main_baselines

--- a/configs/plan_phase_1_metaheuristics.yaml
+++ b/configs/plan_phase_1_metaheuristics.yaml
@@ -63,6 +63,8 @@ rng:
   - 42
   - 43
   - 44
+  - 45
+  - 46
 instances:
   base_dir: data/instances/synthetic
   include:
@@ -74,7 +76,7 @@ instances:
   - n5000_cv_low.json.gz
   - wilson_tree_n10000.json.gz
   - n2000_dense_fast.json.gz
-  manifest_out: data/results_raw/manifest_index.csv
+  manifest_out: data/results_raw/main_metaheuristics/manifest_index.csv
   fields:
   - filename
   - n
@@ -82,4 +84,4 @@ instances:
   - density
   - cv_degree
 output:
-  raw_dir: data/results_raw
+  raw_dir: data/results_raw/main_metaheuristics

--- a/tests/test_canonical_benchmark_plans.py
+++ b/tests/test_canonical_benchmark_plans.py
@@ -25,7 +25,7 @@ def test_phase1_baselines_plan_contains_only_canonical_baselines():
 def test_phase1_metaheuristics_plan_contains_only_canonical_metaheuristics():
     plan = _load_yaml("configs/plan_phase_1_metaheuristics.yaml")
     assert _enabled_solvers(plan) == {"sa", "ils", "grasp", "ts"}
-    assert (plan.get("rng", {}) or {}).get("seeds") == [42, 43, 44]
+    assert (plan.get("rng", {}) or {}).get("seeds") == [42, 43, 44, 45, 46]
 
 
 def test_phase1_pilot_baselines_plan_contains_only_canonical_baselines():


### PR DESCRIPTION
Align main benchmark plans with the canonical 5-seed policy for stochastic participants and separate baseline/meta output surfaces for traceable official execution.