### PR TITLE
fix: allow heterogeneous confirmation CSV rows

### DIFF
--- a/scripts/run_exception_mining_confirmation.py
+++ b/scripts/run_exception_mining_confirmation.py
@@ -778,17 +778,31 @@ def write_json(path: Path, payload: Any) -> None:
 
 
 def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
-    """Write CSV rows."""
+    """Write CSV rows, allowing heterogeneous result dictionaries."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
     if not rows:
         path.write_text("", encoding="utf-8")
         return
 
+    fieldnames = csv_fieldnames(rows)
     with path.open("w", encoding="utf-8", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="raise")
         writer.writeheader()
         writer.writerows(rows)
+
+
+def csv_fieldnames(rows: list[dict[str, Any]]) -> list[str]:
+    """Return deterministic CSV fieldnames across heterogeneous rows."""
+
+    fieldnames: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for key in row:
+            if key not in seen:
+                seen.add(key)
+                fieldnames.append(key)
+    return fieldnames
 
 
 def write_summary_md(path: Path, summary: dict[str, Any]) -> None:

--- a/tests/test_exception_mining_confirmation_runner.py
+++ b/tests/test_exception_mining_confirmation_runner.py
@@ -243,3 +243,42 @@ def test_confirmation_runner_writes_expected_outputs_with_fake_run_one(
         results = list(csv.DictReader(handle))
     assert "screening_stage" not in results[0]
     assert results[0]["confirmation_stage"] == "full_portfolio_confirmation"
+
+
+def test_write_csv_accepts_heterogeneous_confirmation_rows(tmp_path: Path) -> None:
+    module = runpy.run_path("scripts/run_exception_mining_confirmation.py")
+    write_csv = module["write_csv"]
+
+    rows = [
+        {
+            "run_id": "error_first",
+            "algo": "metis",
+            "status": "error",
+            "error_type": "RuntimeError",
+        },
+        {
+            "run_id": "success_second",
+            "algo": "sa",
+            "status": "ok",
+            "cutsize": 10,
+            "elapsed_ms": 1,
+            "beta": 0.03,
+            "checkpoint_count": 1,
+        },
+    ]
+
+    out_csv = tmp_path / "heterogeneous.csv"
+    write_csv(out_csv, rows)
+
+    with out_csv.open("r", encoding="utf-8", newline="") as handle:
+        loaded = list(csv.DictReader(handle))
+
+    assert len(loaded) == 2
+    assert "error_type" in loaded[0]
+    assert "beta" in loaded[0]
+    assert "checkpoint_count" in loaded[0]
+    assert loaded[0]["run_id"] == "error_first"
+    assert loaded[0]["beta"] == ""
+    assert loaded[1]["run_id"] == "success_second"
+    assert loaded[1]["beta"] == "0.03"
+    assert loaded[1]["checkpoint_count"] == "1"


### PR DESCRIPTION
## Summary

Fixes confirmation-runner CSV serialization when raw confirmation rows are heterogeneous.

## Problem

The srv-noctua container gate exposed a real runner bug: when some confirmation rows succeeded and others failed, successful rows contained normalized fields such as beta, n, m, epsilon, checkpoint_count, schema_errors, and raw_status that were not present in the first row used to define the CSV header. The CSV writer then raised:

ValueError: dict contains fields not in fieldnames

## Fix

- Builds CSV fieldnames across all rows before writing.
- Keeps deterministic first-seen field ordering.
- Adds a regression test with an error row followed by a successful row with extra fields.

## Local validation

Passed locally:

- black
- ruff
- pytest tests/test_exception_mining_confirmation_runner.py
- mypy scripts/run_exception_mining_confirmation.py
- confirmation smoke with 1 candidate, 10 algorithms, 1 budget, and 1 seed

Refs #102.
