### PR TITLE
fix: expose Poetry on campaign image login shells

### DIFF
--- a/Dockerfile.campaign
+++ b/Dockerfile.campaign
@@ -49,6 +49,7 @@ RUN git clone --depth 1 --branch "${KAHIP_REF}" https://github.com/KaHIP/KaHIP.g
     && rm -rf /tmp/KaHIP
 
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1 \
+    && ln -sf /opt/poetry/bin/poetry /usr/local/bin/poetry \
     && poetry config virtualenvs.create false
 
 COPY pyproject.toml poetry.lock ./


### PR DESCRIPTION
## Summary

Hardens `Dockerfile.campaign` by exposing Poetry through `/usr/local/bin/poetry`.

## Problem

The post-merge srv-noctua validation for PR #116 failed before campaign execution because the image passed `python --version` but failed under `bash -lc` with:

`poetry: command not found`

The Dockerfile installed Poetry under `/opt/poetry/bin`, but shell initialization under login-shell mode can overwrite `PATH`.

## Fix

Adds a stable symlink:

`/usr/local/bin/poetry -> /opt/poetry/bin/poetry`

This makes Poetry available under both login and non-login shell invocations.

## srv-noctua validation

The patched image was built or reused and gated on `srv-noctua`.

The gate verified:

- `poetry` is available under `bash -lc`;
- `python`, `gpmetis`, `kaffpa`, `cargo`, and `rustc` are available;
- targeted Python tests pass inside the image;
- Rust fidelity binaries build;
- the `srv_noctua_linux_8gb` run plan has 22400 planned runs;
- the 10-participant confirmation smoke has 10/10 valid results;
- confirmation output has no `screening_stage` leakage;
- mounted audit outputs remain user-owned.

## Claim boundary

This PR only fixes and validates the campaign image. It does not start or summarize the evidence-bearing Issue #102 campaign.

Refs #102.
