### PR TITLE
analysis: add srv-noctua CART gatekeeper scripts

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -641,6 +641,18 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
+    {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
+]
+
+[[package]]
 name = "jsmin"
 version = "3.0.1"
 description = "JavaScript minifier."
@@ -1057,7 +1069,7 @@ version = "2.3.3"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ffc4f5caba7dfcbe944ed674b7eef683c7e94874046454bb79ed7ee0236f59d"},
     {file = "numpy-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7e946c7170858a0295f79a60214424caac2ffdb0063d4d79cb681f9aa0aa569"},
@@ -1781,12 +1793,74 @@ files = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+description = "A set of python modules for machine learning and data mining"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c"},
+    {file = "scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd"},
+]
+
+[package.dependencies]
+joblib = ">=1.3.0"
+numpy = ">=1.24.1"
+scipy = ">=1.10.0"
+threadpoolctl = ">=3.2.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.6.1)", "memory_profiler (>=0.57.0)", "pandas (>=1.5.0)"]
+build = ["cython (>=3.1.2)", "meson-python (>=0.17.1)", "numpy (>=1.24.1)", "scipy (>=1.10.0)"]
+docs = ["Pillow (>=10.1.0)", "matplotlib (>=3.6.1)", "memory_profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.5.0)", "plotly (>=5.18.0)", "polars (>=0.20.30)", "pooch (>=1.8.0)", "pydata-sphinx-theme (>=0.15.3)", "scikit-image (>=0.22.0)", "seaborn (>=0.13.0)", "sphinx (>=7.3.7)", "sphinx-copybutton (>=0.5.2)", "sphinx-design (>=0.6.0)", "sphinx-gallery (>=0.17.1)", "sphinx-prompt (>=1.4.0)", "sphinx-remove-toctrees (>=1.0.0.post1)", "sphinxcontrib-sass (>=0.3.4)", "sphinxext-opengraph (>=0.9.1)", "towncrier (>=24.8.0)"]
+examples = ["matplotlib (>=3.6.1)", "pandas (>=1.5.0)", "plotly (>=5.18.0)", "pooch (>=1.8.0)", "scikit-image (>=0.22.0)", "seaborn (>=0.13.0)"]
+install = ["joblib (>=1.3.0)", "numpy (>=1.24.1)", "scipy (>=1.10.0)", "threadpoolctl (>=3.2.0)"]
+maintenance = ["conda-lock (==3.0.1)"]
+tests = ["matplotlib (>=3.6.1)", "mypy (>=1.15)", "numpydoc (>=1.2.0)", "pandas (>=1.5.0)", "polars (>=0.20.30)", "pooch (>=1.8.0)", "pyamg (>=5.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.11.7)"]
+
+[[package]]
 name = "scipy"
 version = "1.16.1"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "scipy-1.16.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:c033fa32bab91dc98ca59d0cf23bb876454e2bb02cbe592d5023138778f70030"},
     {file = "scipy-1.16.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6e5c2f74e5df33479b5cd4e97a9104c511518fbd979aa9b8f6aec18b2e9ecae7"},
@@ -1879,6 +1953,18 @@ files = [
 
 [package.extras]
 widechars = ["wcwidth"]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+description = "threadpoolctl"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb"},
+    {file = "threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e"},
+]
 
 [[package]]
 name = "tqdm"
@@ -2088,4 +2174,4 @@ metrics = ["tqdm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "d3521079c4693dbe361dc70b93fe821a3b713f1a2c5840667511cf33e1699fe5"
+content-hash = "36369dcbd1ce7166fd1c24618ec9864eae5467e50d20cf0abb85c7850575de45"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ mkdocstrings-python = { version = "^1.8.2" }
 griffe              = "^1.5.4"
 pre-commit          = "^3.8.0"
 mkdocs-minify-plugin = "^0.8.0"
+scikit-learn = "^1.8.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.1"

--- a/scripts/run_srv_noctua_cart_gatekeeper.py
+++ b/scripts/run_srv_noctua_cart_gatekeeper.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""Build a pre-training gate report for srv-noctua CART gatekeeper analysis.
+
+This script validates the input contract, joins graph morphology features, and
+materializes split/feature/parameter manifests. It intentionally does not train
+CART yet. Model training is allowed only after this gate report is inspected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+EXPECTED_ENVIRONMENT_ID = "srv_noctua_linux_8gb"
+EXPECTED_CAMPAIGN_ID = "EXP-MULTILEVEL-EXCEPTION-MINING-001"
+
+ALLOWED_FEATURE_COLUMNS = [
+    "num_vertices",
+    "num_edges",
+    "density",
+    "degree_cv",
+    "modularity",
+    "connected_component_count",
+    "largest_component_size",
+]
+
+FIXED_CART_PARAMETER_TUPLE = {
+    "criterion": "gini",
+    "max_depth": 3,
+    "min_samples_leaf": 3,
+    "min_samples_split": 6,
+    "random_state": 20260516,
+    "class_weight": None,
+}
+
+FORBIDDEN_FEATURE_COLUMNS = [
+    "algorithm winner",
+    "best_multilevel_algo",
+    "best_multilevel_cut",
+    "best_meta_python_algo",
+    "best_meta_python_cut",
+    "best_meta_rust_algo",
+    "best_meta_rust_cut",
+    "best_meta_all_algo",
+    "best_meta_all_cut",
+    "relative_gap_meta_all_vs_multilevel",
+    "confirmation_exception_label",
+    "label_claim_status",
+    "median_valid_cut_by_budget",
+    "median_elapsed_ms",
+    "median_seed",
+    "best_valid_cut_by_budget",
+    "best_elapsed_ms",
+    "best_seed",
+    "available_by_budget",
+    "status_set",
+    "environment_id as predictive feature",
+    "file path",
+    "solver-derived columns",
+]
+
+REQUIRED_FILES = {
+    "final_validation": "checks/final_validation_summary.json",
+    "confirmation_summary": "core/confirmation_summary.json",
+    "collapsed": "derived/confirmation_collapsed.csv",
+    "labels": "derived/confirmation_exception_labels.csv",
+    "per_instance": "derived/per_instance_result_summary.csv",
+    "oracle": "derived/sbs_vbs_oracle_gap.csv",
+}
+
+EXPECTED_LABEL_COLUMNS = [
+    "campaign_id",
+    "confirmation_stage",
+    "environment_id",
+    "candidate_id",
+    "family",
+    "environment_target",
+    "variant",
+    "budget_ms",
+    "best_multilevel_algo",
+    "best_multilevel_cut",
+    "best_meta_python_algo",
+    "best_meta_python_cut",
+    "best_meta_rust_algo",
+    "best_meta_rust_cut",
+    "best_meta_all_algo",
+    "best_meta_all_cut",
+    "relative_gap_meta_all_vs_multilevel",
+    "confirmation_exception_label",
+    "label_claim_status",
+]
+
+EXPECTED_ORACLE_COLUMNS = [
+    "campaign_id",
+    "diagnostic",
+    "algo",
+    "available_slice_count",
+    "mean_median_cut",
+    "vbs_mean_median_cut",
+    "oracle_gap_vs_vbs",
+]
+
+
+@dataclass(frozen=True)
+class CsvProfile:
+    """Minimal profile for an input CSV artifact."""
+
+    path: str
+    row_count: int
+    columns: list[str]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Emit a pre-training gate report for srv-noctua CART."
+    )
+    parser.add_argument(
+        "--bundle",
+        type=Path,
+        required=True,
+        help="Path to srv-noctua evidence bundle.",
+    )
+    parser.add_argument(
+        "--candidate-pool-root",
+        type=Path,
+        required=True,
+        help="Path to exploratory_pool_001 containing candidate bundles.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Local audit output directory. Should be under audit_reports/.",
+    )
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object at {path}")
+    return payload
+
+
+def profile_csv(path: Path) -> CsvProfile:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        columns = list(reader.fieldnames or [])
+        row_count = sum(1 for _ in reader)
+    return CsvProfile(path=str(path), row_count=row_count, columns=columns)
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def entropy(counts: Counter[str]) -> float:
+    total = sum(counts.values())
+    if total <= 0:
+        return 0.0
+    value = 0.0
+    for count in counts.values():
+        if count:
+            p = count / total
+            value -= p * math.log2(p)
+    return value
+
+
+def require_columns(actual: list[str], expected: list[str]) -> list[str]:
+    actual_set = set(actual)
+    return [column for column in expected if column not in actual_set]
+
+
+def build_multilevel_sufficiency_target(label: str) -> str:
+    if label in {"strong_exception_confirmed", "near_tie_confirmed", "competitive_confirmed"}:
+        return "multilevel_not_sufficient_or_not_decisively_dominant"
+    if label == "non_exception_confirmed":
+        return "multilevel_sufficient"
+    return "unknown_or_insufficient"
+
+
+def to_float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def discover_graph_metrics(candidate_pool_root: Path) -> dict[str, dict[str, Any]]:
+    metrics_by_candidate: dict[str, dict[str, Any]] = {}
+    for path in sorted(candidate_pool_root.glob("bundles/*/*/graph_metrics.json")):
+        candidate_id = path.parent.name
+        metrics = read_json(path)
+        metrics_by_candidate[candidate_id] = {
+            "metrics_path": str(path),
+            **metrics,
+        }
+    return metrics_by_candidate
+
+
+def build_feature_table(
+    label_rows: list[dict[str, str]],
+    metrics_by_candidate: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    missing_metrics: list[str] = []
+    missing_features: dict[str, list[str]] = {}
+    non_numeric_features: dict[str, dict[str, Any]] = {}
+    null_feature_counts: Counter[str] = Counter()
+
+    for label_row in label_rows:
+        candidate_id = label_row["candidate_id"]
+        metrics = metrics_by_candidate.get(candidate_id)
+        if metrics is None:
+            missing_metrics.append(candidate_id)
+            continue
+
+        out: dict[str, Any] = {
+            "candidate_id": candidate_id,
+            "family": label_row["family"],
+            "environment_target": label_row["environment_target"],
+            "variant": label_row["variant"],
+            "budget_ms": int(label_row["budget_ms"]),
+            "target_multilevel_sufficiency": build_multilevel_sufficiency_target(
+                label_row["confirmation_exception_label"]
+            ),
+        }
+
+        missing_here: list[str] = []
+        bad_here: dict[str, Any] = {}
+
+        for column in ALLOWED_FEATURE_COLUMNS:
+            raw = metrics.get(column)
+            value = to_float_or_none(raw)
+            if value is None:
+                missing_here.append(column)
+                null_feature_counts[column] += 1
+            elif raw not in (None, "") and not isinstance(raw, (int, float)):
+                try:
+                    float(raw)
+                except Exception:
+                    bad_here[column] = raw
+            out[column] = value
+
+        if missing_here:
+            missing_features[candidate_id] = missing_here
+        if bad_here:
+            non_numeric_features[candidate_id] = bad_here
+
+        rows.append(out)
+
+    diagnostics = {
+        "row_count": len(rows),
+        "candidate_count": len({row["candidate_id"] for row in rows}),
+        "missing_metrics_for_label_rows": sorted(set(missing_metrics)),
+        "candidates_with_missing_features": missing_features,
+        "non_numeric_features": non_numeric_features,
+        "null_feature_counts": dict(sorted(null_feature_counts.items())),
+    }
+    return rows, diagnostics
+
+
+def build_split_manifest(feature_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build deterministic family-holdout split manifest.
+
+    This is a conservative pretraining split contract, not yet a performance
+    claim. Families F01 and F05 are held out based on the audited split-support probe
+    927. This deterministic family holdout preserves both target classes in
+    train and test while maintaining a family-level leakage boundary. The target
+    remains highly imbalanced and any future classifier metric must report that
+    limitation explicitly.
+    """
+
+    test_families = {"F01", "F05"}
+    by_candidate: dict[str, dict[str, Any]] = {}
+
+    for row in feature_rows:
+        candidate_id = str(row["candidate_id"])
+        family = str(row["family"])
+        by_candidate.setdefault(
+            candidate_id,
+            {
+                "candidate_id": candidate_id,
+                "family": family,
+                "environment_target": str(row["environment_target"]),
+                "variant": str(row["variant"]),
+                "split": "test" if family in test_families else "train",
+                "split_policy": "deterministic_family_holdout_F01_F05",
+            },
+        )
+
+    return [by_candidate[key] for key in sorted(by_candidate)]
+
+
+def summarize_split(
+    split_manifest: list[dict[str, Any]], feature_rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    candidate_split = {row["candidate_id"]: row["split"] for row in split_manifest}
+    candidate_family = {row["candidate_id"]: row["family"] for row in split_manifest}
+
+    split_counts = Counter(row["split"] for row in split_manifest)
+    family_by_split: dict[str, Counter[str]] = defaultdict(Counter)
+    target_by_split: dict[str, Counter[str]] = defaultdict(Counter)
+
+    for row in feature_rows:
+        split = candidate_split[str(row["candidate_id"])]
+        family_by_split[split][candidate_family[str(row["candidate_id"])]] += 1
+        target_by_split[split][str(row["target_multilevel_sufficiency"])] += 1
+
+    return {
+        "split_policy": "deterministic_family_holdout_F01_F05",
+        "split_unit": "candidate_id",
+        "test_families": ["F01", "F05"],
+        "candidate_split_counts": dict(sorted(split_counts.items())),
+        "family_row_counts_by_split": {
+            split: dict(sorted(counter.items()))
+            for split, counter in sorted(family_by_split.items())
+        },
+        "target_row_counts_by_split": {
+            split: dict(sorted(counter.items()))
+            for split, counter in sorted(target_by_split.items())
+        },
+        "budget_rows_stay_with_candidate": True,
+    }
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def write_markdown(path: Path, report: dict[str, Any]) -> None:
+    lines: list[str] = []
+    lines.append("# srv-noctua CART gatekeeper pretraining report")
+    lines.append("")
+    lines.append("## Status")
+    lines.append("")
+    lines.append(f"- Gate result: `{report['gate_result']}`")
+    lines.append(f"- Training executed: `{report['training_executed']}`")
+    lines.append(f"- Claim status: `{report['claim_status']}`")
+    lines.append("")
+    lines.append("## Evidence boundary")
+    lines.append("")
+    for key, value in report["evidence_boundary"].items():
+        lines.append(f"- {key}: `{value}`")
+    lines.append("")
+    lines.append("## Feature contract")
+    lines.append("")
+    fc = report["feature_contract"]
+    lines.append(f"- Feature joining implemented: `{fc['graph_feature_joining_implemented']}`")
+    lines.append(f"- Allowed feature columns: `{fc['allowed_feature_columns']}`")
+    lines.append(
+        f"- Null feature counts: `{fc['feature_join_diagnostics']['null_feature_counts']}`"
+    )
+    lines.append(
+        f"- Missing metrics: `{fc['feature_join_diagnostics']['missing_metrics_for_label_rows']}`"
+    )
+    lines.append(
+        f"- Missing feature candidates: `{fc['feature_join_diagnostics']['candidates_with_missing_features']}`"
+    )
+    lines.append("")
+    lines.append("## Split contract")
+    lines.append("")
+    split = report["split_contract"]
+    lines.append(f"- Split implemented: `{split['split_implemented']}`")
+    lines.append(f"- Split policy: `{split['split_summary']['split_policy']}`")
+    lines.append(f"- Candidate split counts: `{split['split_summary']['candidate_split_counts']}`")
+    lines.append(
+        f"- Target row counts by split: `{split['split_summary']['target_row_counts_by_split']}`"
+    )
+    lines.append("")
+    lines.append("## Fixed CART tuple")
+    lines.append("")
+    lines.append(f"- Parameters: `{report['fixed_cart_parameter_tuple']}`")
+    lines.append("")
+    lines.append("## Label diagnostics")
+    lines.append("")
+    label_diag = report["label_diagnostics"]
+    lines.append(f"- Label counts: `{label_diag['label_counts']}`")
+    lines.append(f"- Candidate target counts: `{label_diag['candidate_target_counts']}`")
+    lines.append(f"- Label entropy bits: `{label_diag['label_entropy_bits']}`")
+    lines.append("")
+    lines.append("## Blocking items before training")
+    lines.append("")
+    for item in report["blocking_items_before_training"]:
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("## Explicit non-claims")
+    lines.append("")
+    for item in report["explicit_non_claims"]:
+        lines.append(f"- {item}")
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    bundle = args.bundle
+    output_dir = args.output_dir
+
+    resolved = {name: bundle / rel for name, rel in REQUIRED_FILES.items()}
+    missing_files = [str(path) for path in resolved.values() if not path.exists()]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if missing_files:
+        failure = {
+            "gate_result": "fail_missing_required_files",
+            "missing_files": missing_files,
+            "training_executed": False,
+        }
+        write_json(output_dir / "gate_report.json", failure)
+        return 2
+
+    final_validation = read_json(resolved["final_validation"])
+    confirmation_summary = read_json(resolved["confirmation_summary"])
+
+    csv_profiles = {
+        name: profile_csv(path).__dict__ for name, path in resolved.items() if path.suffix == ".csv"
+    }
+
+    missing_expected_columns = {
+        "labels": require_columns(csv_profiles["labels"]["columns"], EXPECTED_LABEL_COLUMNS),
+        "oracle": require_columns(csv_profiles["oracle"]["columns"], EXPECTED_ORACLE_COLUMNS),
+    }
+
+    label_rows = read_csv_rows(resolved["labels"])
+    label_counts = Counter(row.get("confirmation_exception_label", "") for row in label_rows)
+    target_counts = Counter(
+        build_multilevel_sufficiency_target(row.get("confirmation_exception_label", ""))
+        for row in label_rows
+    )
+
+    oracle_rows = read_csv_rows(resolved["oracle"])
+    metrics_by_candidate = discover_graph_metrics(args.candidate_pool_root)
+    feature_rows, feature_join_diagnostics = build_feature_table(label_rows, metrics_by_candidate)
+    split_manifest = build_split_manifest(feature_rows)
+    split_summary = summarize_split(split_manifest, feature_rows)
+
+    environment_id = str(final_validation.get("environment_id", ""))
+    campaign_id = str(final_validation.get("campaign_id", ""))
+
+    blocking_items: list[str] = []
+    if environment_id != EXPECTED_ENVIRONMENT_ID:
+        blocking_items.append(
+            f"Unexpected environment_id: {environment_id!r}; expected {EXPECTED_ENVIRONMENT_ID!r}."
+        )
+    if campaign_id != EXPECTED_CAMPAIGN_ID:
+        blocking_items.append(
+            f"Unexpected campaign_id: {campaign_id!r}; expected {EXPECTED_CAMPAIGN_ID!r}."
+        )
+    if missing_expected_columns["labels"]:
+        blocking_items.append("Missing expected columns in confirmation_exception_labels.csv.")
+    if missing_expected_columns["oracle"]:
+        blocking_items.append("Missing expected columns in sbs_vbs_oracle_gap.csv.")
+    if feature_join_diagnostics["missing_metrics_for_label_rows"]:
+        blocking_items.append("Some label rows have no graph_metrics.json join.")
+    if feature_join_diagnostics["non_numeric_features"]:
+        blocking_items.append("Some allowed features are non-numeric.")
+
+    blocking_items.extend(
+        [
+            "CART training has not yet been executed in this script version.",
+            "Any future model result must be interpreted against the deterministic family-holdout split contract.",
+            "The current target is highly imbalanced; any classifier metric must report this explicitly.",
+        ]
+    )
+
+    gate_result = (
+        "pass_pretraining_feature_split_contract_ready"
+        if not missing_expected_columns["labels"]
+        and not missing_expected_columns["oracle"]
+        and environment_id == EXPECTED_ENVIRONMENT_ID
+        and campaign_id == EXPECTED_CAMPAIGN_ID
+        and not feature_join_diagnostics["missing_metrics_for_label_rows"]
+        and not feature_join_diagnostics["non_numeric_features"]
+        else "fail_pretraining_feature_split_contract"
+    )
+
+    report: dict[str, Any] = {
+        "gate_result": gate_result,
+        "training_executed": False,
+        "claim_status": "pretraining_feature_split_contract_only_no_cart_performance_claim",
+        "evidence_boundary": {
+            "campaign_id": campaign_id,
+            "environment_id": environment_id,
+            "environment_pooling_status": "forbidden_single_environment_slice_only",
+            "bundle": str(bundle),
+            "candidate_pool_root": str(args.candidate_pool_root),
+            "versioning_boundary": "audit_reports_local_only_not_versioned",
+        },
+        "validation_summary": {
+            "planned_run_count": final_validation.get("planned_run_count"),
+            "raw_result_count": final_validation.get("raw_result_count"),
+            "valid_result_count": final_validation.get("valid_result_count"),
+            "invalid_result_count": final_validation.get("invalid_result_count"),
+            "missing_artifact_count": final_validation.get("missing_artifact_count"),
+            "schema_error_count_total": final_validation.get("schema_error_count_total"),
+            "collapsed_row_count": final_validation.get("collapsed_row_count"),
+            "label_row_count": final_validation.get("label_row_count"),
+            "monograph_claim_status": final_validation.get("monograph_claim_status"),
+        },
+        "csv_profiles": csv_profiles,
+        "missing_expected_columns": missing_expected_columns,
+        "label_diagnostics": {
+            "label_row_count": len(label_rows),
+            "label_counts": dict(sorted(label_counts.items())),
+            "label_entropy_bits": round(entropy(label_counts), 6),
+            "candidate_target_name": "multilevel_sufficiency_or_exception",
+            "candidate_target_counts": dict(sorted(target_counts.items())),
+        },
+        "oracle_diagnostics": {
+            "sbs_algo": confirmation_summary.get("sbs_algo"),
+            "vbs_mean_median_cut": confirmation_summary.get("vbs_mean_median_cut"),
+            "oracle_row_count": len(oracle_rows),
+        },
+        "feature_contract": {
+            "graph_feature_joining_implemented": True,
+            "allowed_feature_source": "graph_metrics.json from candidate bundles",
+            "allowed_feature_columns": ALLOWED_FEATURE_COLUMNS,
+            "forbidden_feature_columns": FORBIDDEN_FEATURE_COLUMNS,
+            "feature_join_diagnostics": feature_join_diagnostics,
+        },
+        "split_contract": {
+            "split_implemented": True,
+            "split_summary": split_summary,
+        },
+        "fixed_cart_parameter_tuple": FIXED_CART_PARAMETER_TUPLE,
+        "blocking_items_before_training": blocking_items,
+        "explicit_non_claims": [
+            "This report does not train CART.",
+            "This report does not authorize a universal solver selector claim.",
+            "This report does not authorize environment-pooled conclusions.",
+            "This report does not update monograph prose.",
+            "This report does not version audit_reports artifacts.",
+        ],
+    }
+
+    feature_fieldnames = [
+        "candidate_id",
+        "family",
+        "environment_target",
+        "variant",
+        "budget_ms",
+        *ALLOWED_FEATURE_COLUMNS,
+        "target_multilevel_sufficiency",
+    ]
+    split_fieldnames = [
+        "candidate_id",
+        "family",
+        "environment_target",
+        "variant",
+        "split",
+        "split_policy",
+    ]
+
+    write_json(output_dir / "gate_report.json", report)
+    write_markdown(output_dir / "gate_report.md", report)
+    write_csv(output_dir / "cart_feature_table.csv", feature_rows, feature_fieldnames)
+    write_json(output_dir / "cart_feature_table.json", feature_rows)
+    write_csv(output_dir / "split_manifest.csv", split_manifest, split_fieldnames)
+    write_json(output_dir / "split_manifest.json", split_manifest)
+    write_json(
+        output_dir / "allowed_feature_manifest.json",
+        {
+            "allowed_feature_columns": ALLOWED_FEATURE_COLUMNS,
+            "forbidden_feature_columns": FORBIDDEN_FEATURE_COLUMNS,
+            "fixed_cart_parameter_tuple": FIXED_CART_PARAMETER_TUPLE,
+            "target": "multilevel_sufficiency_or_exception",
+        },
+    )
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train_srv_noctua_cart_gatekeeper.py
+++ b/scripts/train_srv_noctua_cart_gatekeeper.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Train the first bounded CART gatekeeper for srv-noctua evidence.
+
+This script consumes the pretraining artifacts produced by
+run_srv_noctua_cart_gatekeeper.py. It is intentionally claim-bounded:
+it trains a fixed CART under the audited split and writes local audit reports;
+it does not authorize universal selector claims or monograph prose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+GRAPH_FEATURE_COLUMNS = [
+    "num_vertices",
+    "num_edges",
+    "density",
+    "degree_cv",
+    "modularity",
+    "connected_component_count",
+    "largest_component_size",
+]
+
+CONTEXT_FEATURE_COLUMNS = [
+    "budget_ms",
+]
+
+MODEL_FEATURE_COLUMNS = CONTEXT_FEATURE_COLUMNS + GRAPH_FEATURE_COLUMNS
+
+TARGET_COLUMN = "target_multilevel_sufficiency"
+
+CLASS_LABELS = [
+    "multilevel_not_sufficient_or_not_decisively_dominant",
+    "multilevel_sufficient",
+]
+
+FIXED_CART_PARAMETER_TUPLE = {
+    "criterion": "gini",
+    "max_depth": 3,
+    "min_samples_leaf": 3,
+    "min_samples_split": 6,
+    "random_state": 20260516,
+    "class_weight": None,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train fixed CART gatekeeper on srv-noctua audited split."
+    )
+    parser.add_argument("--feature-table", type=Path, required=True)
+    parser.add_argument("--split-manifest", type=Path, required=True)
+    parser.add_argument("--gate-report", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def read_csv_dicts(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def to_float(value: str) -> float | None:
+    if value in ("", "None", "null", "NULL"):
+        return None
+    return float(value)
+
+
+def load_dataset(
+    feature_table: Path,
+    split_manifest: Path,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    feature_rows_raw = read_csv_dicts(feature_table)
+    split_rows = read_csv_dicts(split_manifest)
+
+    split_by_candidate = {row["candidate_id"]: row for row in split_rows}
+
+    missing_split = sorted(
+        {
+            row["candidate_id"]
+            for row in feature_rows_raw
+            if row["candidate_id"] not in split_by_candidate
+        }
+    )
+    if missing_split:
+        raise ValueError(f"feature rows without split manifest entries: {missing_split[:20]}")
+
+    rows: list[dict[str, Any]] = []
+    for row in feature_rows_raw:
+        candidate_id = row["candidate_id"]
+        split_row = split_by_candidate[candidate_id]
+        out: dict[str, Any] = {
+            "candidate_id": candidate_id,
+            "family": row["family"],
+            "environment_target": row["environment_target"],
+            "variant": row["variant"],
+            "split": split_row["split"],
+            TARGET_COLUMN: row[TARGET_COLUMN],
+        }
+        for column in MODEL_FEATURE_COLUMNS:
+            out[column] = to_float(row[column])
+        rows.append(out)
+
+    split_summary = {
+        "candidate_split_counts": dict(Counter(row["split"] for row in split_rows)),
+        "row_split_counts": dict(Counter(row["split"] for row in rows)),
+        "target_counts_by_split": {
+            split: dict(Counter(row[TARGET_COLUMN] for row in rows if row["split"] == split))
+            for split in sorted({row["split"] for row in rows})
+        },
+        "family_counts_by_split": {
+            split: dict(Counter(row["family"] for row in rows if row["split"] == split))
+            for split in sorted({row["split"] for row in rows})
+        },
+        "split_policy_values": sorted({row.get("split_policy", "") for row in split_rows}),
+    }
+
+    return rows, split_summary
+
+
+def make_matrix(rows: list[dict[str, Any]]):
+    import numpy as np
+
+    x = np.array(
+        [[row[column] for column in MODEL_FEATURE_COLUMNS] for row in rows],
+        dtype=float,
+    )
+    y = np.array([row[TARGET_COLUMN] for row in rows], dtype=object)
+    return x, y
+
+
+def majority_baseline(
+    train_rows: list[dict[str, Any]], eval_rows: list[dict[str, Any]]
+) -> list[str]:
+    counts = Counter(row[TARGET_COLUMN] for row in train_rows)
+    majority = counts.most_common(1)[0][0]
+    return [majority for _ in eval_rows]
+
+
+def compute_metrics(y_true, y_pred) -> dict[str, Any]:
+    from sklearn.metrics import (
+        accuracy_score,
+        balanced_accuracy_score,
+        classification_report,
+        confusion_matrix,
+        f1_score,
+        precision_score,
+        recall_score,
+    )
+
+    return {
+        "accuracy": float(accuracy_score(y_true, y_pred)),
+        "balanced_accuracy": float(balanced_accuracy_score(y_true, y_pred)),
+        "macro_f1": float(f1_score(y_true, y_pred, average="macro", zero_division=0)),
+        "weighted_f1": float(f1_score(y_true, y_pred, average="weighted", zero_division=0)),
+        "macro_precision": float(precision_score(y_true, y_pred, average="macro", zero_division=0)),
+        "macro_recall": float(recall_score(y_true, y_pred, average="macro", zero_division=0)),
+        "confusion_matrix_labels": CLASS_LABELS,
+        "confusion_matrix": confusion_matrix(y_true, y_pred, labels=CLASS_LABELS).tolist(),
+        "classification_report": classification_report(
+            y_true,
+            y_pred,
+            labels=CLASS_LABELS,
+            output_dict=True,
+            zero_division=0,
+        ),
+        "prediction_counts": dict(Counter(str(label) for label in y_pred)),
+        "true_counts": dict(Counter(str(label) for label in y_true)),
+    }
+
+
+def train_and_evaluate(
+    rows: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]], str]:
+    from sklearn.impute import SimpleImputer
+    from sklearn.pipeline import Pipeline
+    from sklearn.tree import DecisionTreeClassifier, export_text
+
+    train_rows = [row for row in rows if row["split"] == "train"]
+    test_rows = [row for row in rows if row["split"] == "test"]
+
+    if not train_rows or not test_rows:
+        raise ValueError("train/test split must both be non-empty")
+
+    train_targets = Counter(row[TARGET_COLUMN] for row in train_rows)
+    test_targets = Counter(row[TARGET_COLUMN] for row in test_rows)
+
+    if len(train_targets) < 2 or len(test_targets) < 2:
+        raise ValueError(
+            f"train and test must both contain both target classes; "
+            f"train={dict(train_targets)}, test={dict(test_targets)}"
+        )
+
+    x_train, y_train = make_matrix(train_rows)
+    x_test, y_test = make_matrix(test_rows)
+
+    pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            ("cart", DecisionTreeClassifier(**FIXED_CART_PARAMETER_TUPLE)),
+        ]
+    )
+    pipeline.fit(x_train, y_train)
+
+    train_pred = pipeline.predict(x_train)
+    test_pred = pipeline.predict(x_test)
+
+    baseline_train_pred = majority_baseline(train_rows, train_rows)
+    baseline_test_pred = majority_baseline(train_rows, test_rows)
+
+    model = pipeline.named_steps["cart"]
+    tree_text = export_text(model, feature_names=MODEL_FEATURE_COLUMNS)
+
+    feature_importances = {
+        feature: float(importance)
+        for feature, importance in zip(
+            MODEL_FEATURE_COLUMNS, model.feature_importances_, strict=False
+        )
+    }
+
+    predictions: list[dict[str, Any]] = []
+    for source_rows, y_pred in [(train_rows, train_pred), (test_rows, test_pred)]:
+        for row, pred in zip(source_rows, y_pred, strict=False):
+            predictions.append(
+                {
+                    "candidate_id": row["candidate_id"],
+                    "family": row["family"],
+                    "environment_target": row["environment_target"],
+                    "variant": row["variant"],
+                    "budget_ms": int(row["budget_ms"]),
+                    "split": row["split"],
+                    "target": row[TARGET_COLUMN],
+                    "prediction": str(pred),
+                    "correct": str(row[TARGET_COLUMN] == str(pred)),
+                }
+            )
+
+    report = {
+        "training_executed": True,
+        "claim_status": "bounded_first_cart_training_no_universal_selector_claim",
+        "target": TARGET_COLUMN,
+        "target_interpretation": "budget-row multilevel sufficiency/exception gate",
+        "model_feature_columns": MODEL_FEATURE_COLUMNS,
+        "graph_feature_columns": GRAPH_FEATURE_COLUMNS,
+        "context_feature_columns": CONTEXT_FEATURE_COLUMNS,
+        "fixed_cart_parameter_tuple": FIXED_CART_PARAMETER_TUPLE,
+        "preprocessing": {
+            "imputer": "SimpleImputer(strategy='median')",
+            "reason": "modularity contains null values in part of the audited feature table",
+        },
+        "split_policy": "deterministic_family_holdout_F01_F05",
+        "metrics": {
+            "train": compute_metrics(y_train, train_pred),
+            "test": compute_metrics(y_test, test_pred),
+            "majority_baseline_train": compute_metrics(y_train, baseline_train_pred),
+            "majority_baseline_test": compute_metrics(y_test, baseline_test_pred),
+        },
+        "feature_importances": feature_importances,
+        "warnings": [
+            "The target is highly imbalanced.",
+            "The training split contains only 3 multilevel_sufficient rows.",
+            "The test split contains 8 multilevel_sufficient rows, all from held-out F05.",
+            "This is a bounded diagnostic gatekeeper model, not a universal solver selector.",
+            "No monograph prose should be updated until results are mapped in decisions/08_Results_to_Text_Map.md.",
+        ],
+    }
+
+    return report, predictions, tree_text
+
+
+def write_markdown(path: Path, report: dict[str, Any]) -> None:
+    lines: list[str] = []
+    lines.append("# First srv-noctua CART gatekeeper training report")
+    lines.append("")
+    lines.append("## Status")
+    lines.append("")
+    lines.append(f"- Training executed: `{report['training_executed']}`")
+    lines.append(f"- Claim status: `{report['claim_status']}`")
+    lines.append(f"- Target: `{report['target']}`")
+    lines.append(f"- Target interpretation: `{report['target_interpretation']}`")
+    lines.append(f"- Split policy: `{report['split_policy']}`")
+    lines.append("")
+    lines.append("## Features and preprocessing")
+    lines.append("")
+    lines.append(f"- Model feature columns: `{report['model_feature_columns']}`")
+    lines.append(f"- Graph feature columns: `{report['graph_feature_columns']}`")
+    lines.append(f"- Context feature columns: `{report['context_feature_columns']}`")
+    lines.append(f"- Fixed CART tuple: `{report['fixed_cart_parameter_tuple']}`")
+    lines.append(f"- Preprocessing: `{report['preprocessing']}`")
+    lines.append("")
+    lines.append("## Test metrics")
+    lines.append("")
+    test = report["metrics"]["test"]
+    baseline = report["metrics"]["majority_baseline_test"]
+    lines.append(f"- CART accuracy: `{test['accuracy']}`")
+    lines.append(f"- CART balanced accuracy: `{test['balanced_accuracy']}`")
+    lines.append(f"- CART macro F1: `{test['macro_f1']}`")
+    lines.append(f"- CART confusion matrix labels: `{test['confusion_matrix_labels']}`")
+    lines.append(f"- CART confusion matrix: `{test['confusion_matrix']}`")
+    lines.append(f"- Majority baseline accuracy: `{baseline['accuracy']}`")
+    lines.append(f"- Majority baseline balanced accuracy: `{baseline['balanced_accuracy']}`")
+    lines.append(f"- Majority baseline macro F1: `{baseline['macro_f1']}`")
+    lines.append(f"- Majority baseline confusion matrix: `{baseline['confusion_matrix']}`")
+    lines.append("")
+    lines.append("## Feature importances")
+    lines.append("")
+    for feature, value in sorted(report["feature_importances"].items()):
+        lines.append(f"- `{feature}`: `{value}`")
+    lines.append("")
+    lines.append("## Warnings")
+    lines.append("")
+    for warning in report["warnings"]:
+        lines.append(f"- {warning}")
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    gate_report = json.loads(args.gate_report.read_text(encoding="utf-8"))
+    if gate_report.get("gate_result") != "pass_pretraining_feature_split_contract_ready":
+        raise ValueError(
+            "gate report is not ready for bounded training: " + repr(gate_report.get("gate_result"))
+        )
+
+    rows, split_summary = load_dataset(args.feature_table, args.split_manifest)
+    training_report, predictions, tree_text = train_and_evaluate(rows)
+
+    output = {
+        "input_gate_report": str(args.gate_report),
+        "feature_table": str(args.feature_table),
+        "split_manifest": str(args.split_manifest),
+        "split_summary": split_summary,
+        **training_report,
+    }
+
+    write_json(args.output_dir / "cart_training_report.json", output)
+    write_markdown(args.output_dir / "cart_training_report.md", output)
+    (args.output_dir / "cart_tree.txt").write_text(tree_text, encoding="utf-8")
+    write_csv(
+        args.output_dir / "cart_predictions.csv",
+        predictions,
+        [
+            "candidate_id",
+            "family",
+            "environment_target",
+            "variant",
+            "budget_ms",
+            "split",
+            "target",
+            "prediction",
+            "correct",
+        ],
+    )
+
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a bounded `srv-noctua` CART gatekeeper analysis surface.

This PR introduces:

- `scikit-learn` as a development/analysis dependency;
- a pre-training input-contract script for the declared `srv_noctua_linux_8gb` evidence stratum;
- a fixed CART training script that consumes the audited local gate artifacts;
- explicit claim boundaries preventing a positive or universal selector interpretation.

## Result boundary

The first local run produced a negative/limited CART gate result:

- audited split: `deterministic_family_holdout_F01_F05`;
- target: `target_multilevel_sufficiency`;
- held-out CART result matched the majority baseline;
- the model predicted no `multilevel_sufficient` rows in the test split;
- interpretation: reproducible bounded negative/limited gate, not positive selector evidence.

## Validation

Local validation before commit:

- pre-commit hooks passed;
- `pytest -m smoke` passed through pre-commit;
- full smoke passed with `PYTHONPATH=src`;
- after editable package install, focused subprocess CLI tests passed without `PYTHONPATH`;
- after editable package install, full smoke passed without `PYTHONPATH`.

## Non-versioned evidence boundary

No generated CART reports, local evidence bundles, or `audit_reports/` files are versioned.

The PR only commits:

- `pyproject.toml`;
- `poetry.lock`;
- `scripts/run_srv_noctua_cart_gatekeeper.py`;
- `scripts/train_srv_noctua_cart_gatekeeper.py`.

## Claim discipline

Allowed claim:

- reproducible bounded CART gate scripts with a negative/limited held-out result.

Forbidden claim:

- CART is validated as a positive or universal solver selector.

No monograph prose should be updated until this result is mapped in `decisions/08_Results_to_Text_Map.md`.
