### PR TITLE
docs: define data storage policy for M1 source audits

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,50 @@
+# Data directory policy
+
+This directory separates versioned curated inputs from local-only execution, cache and temporary material.
+
+## Versioned data
+
+`data/instances/` is the versioned location for curated benchmark instances and lightweight metadata manifests.
+
+Files under `data/instances/` may be committed only when they are intentionally curated project inputs or lightweight documentation/metadata needed to reproduce the benchmark protocol.
+
+The current real-graph confirmatory curation manifest is:
+
+- `data/instances/real/confirmatory_real_graph_candidates.csv`
+
+## Local-only data
+
+The following paths are local-only and ignored by Git:
+
+- `data/cache/`
+- `data/tmp/`
+- `data/results_raw/`
+- `data/results_parquet/`
+
+Use `data/cache/external_sources/` for downloaded external source archives such as SNAP `.txt.gz` files when a source audit requires local raw inputs.
+
+Use `data/tmp/` for scratch transformations, intermediate conversion products and disposable working files.
+
+Use `data/results_raw/` and `data/results_parquet/` for execution outputs and derived result tables, not for external source inputs.
+
+## audit_reports boundary
+
+`audit_reports/` is not a data cache.
+
+Use `audit_reports/` only for terminal logs, command outputs, action records and chat-interaction audit notes. Do not store raw datasets, downloaded source archives, execution inputs, cache files or transformation scratch files there.
+
+A command log may mention paths, checksums and summaries, but the raw files themselves must live outside `audit_reports/`.
+
+## Raw external sources
+
+Raw external source files must not be committed unless a later issue explicitly defines a specific file as a versioned source artifact and records why that is necessary.
+
+For M1 real-graph curation, raw SNAP files may be downloaded only to a local ignored cache such as:
+
+- `data/cache/external_sources/snap/`
+
+Any versioned metadata derived from those files must avoid relying on a private absolute path. It should record stable public source information, checksum, file size, retrieval date or HTTP metadata when available, and the command or script used to reproduce the audit.
+
+## Current M1 boundary
+
+The M1 real-graph manifest documents candidates. It does not admit candidates to M3 smoke or M4 execution while license, raw-source audit, morphology descriptors or holdout policy remain incomplete.

--- a/data/instances/real/CONFIRMATORY_REAL_GRAPH_CURATION.md
+++ b/data/instances/real/CONFIRMATORY_REAL_GRAPH_CURATION.md
@@ -59,6 +59,24 @@ Real-graph candidates must not be selected, excluded, resized or promoted based 
 
 Candidate inclusion must be justified by provenance, license, auditability, morphology coverage, size feasibility and holdout grouping.
 
+## Repository storage policy for M1 source audits
+
+Raw external source files must not be downloaded into `audit_reports/`.
+
+For this project workflow, `audit_reports/` is limited to terminal logs, command outputs, action records and chat-interaction audit notes. It must not be used as a storage area for raw datasets, downloaded source archives, execution inputs, cache files or transformation scratch files.
+
+When M1 source auditing requires local raw files, use an ignored local cache such as:
+
+- `data/cache/external_sources/snap/`
+
+When conversion or inspection requires disposable intermediates, use:
+
+- `data/tmp/`
+
+Curated benchmark instances and lightweight metadata manifests belong under `data/instances/` only after they are intentionally selected as versioned repository inputs.
+
+This policy corrects the earlier workflow error in which raw SNAP files were temporarily downloaded under `audit_reports/`. Those files were removed and no metadata from that incorrect location is accepted as a source-of-truth manifest update.
+
 ## Raw data policy
 
 Do not add new raw graph archives or large downloaded datasets in M1 unless a later issue explicitly defines that artifact as versioned source.


### PR DESCRIPTION
## Summary

Defines the repository data-storage policy needed to continue M1 source audits safely.

This PR adds/updates:

- `data/README.md`;
- `data/instances/real/CONFIRMATORY_REAL_GRAPH_CURATION.md`.

## What this does

- States that `audit_reports/` is not a data cache.
- Restricts `audit_reports/` to terminal logs, command outputs, action records and chat-interaction audit notes.
- Defines `data/cache/external_sources/` as the ignored local location for downloaded external source archives.
- Defines `data/tmp/` as scratch space for temporary transformations.
- Preserves `data/instances/` as the versioned location for curated benchmark instances and lightweight metadata manifests.
- Records that the earlier raw SNAP download into `audit_reports/` was a workflow error and that no metadata from that incorrect location is accepted as source-of-truth.

## Claim boundary

This PR does not add empirical results and does not promote any real-graph candidate.

It explicitly keeps these boundaries:

- no raw external source archive is downloaded;
- no cache/tmp/results file is added;
- no existing `.json.gz` graph asset is modified;
- no final monograph prose is edited;
- no new result-to-text claim is added;
- `audit_reports/` remains unversioned;
- issue #127 remains open.

## Validation

- Policy content validation passed.
- Pre-commit passed.
- No `.tex`, `.bib`, `decisions/08_Results_to_Text_Map.md`, raw graph, cache/tmp/results, or `audit_reports/` path was changed.

Refs #127.
