### PR TITLE
docs: record srv-noctua-first real graph curation policy

### DIFF
--- a/data/instances/real/LICENSE_CLEAR_REPLACEMENT_CURATION.md
+++ b/data/instances/real/LICENSE_CLEAR_REPLACEMENT_CURATION.md
@@ -14,6 +14,26 @@ The original SNAP-derived M1 candidates were excluded from the public confirmato
 
 The replacement path must therefore use license-clear sources. No candidate family in this file is admitted to M3 smoke or M4 confirmatory execution yet.
 
+## Environment policy
+
+Real-graph replacement curation follows the `srv-noctua`-first policy recorded in:
+
+- `data/instances/real/REAL_GRAPH_CURATION_ENVIRONMENT_POLICY.md`
+
+Documentation-only changes may be prepared locally, but any step that downloads data, computes hashes, derives graphs, validates non-trivial graph structure, runs M3/M4 or trains CART should run on `srv-noctua` by default.
+
+Future data-producing scripts should include an explicit environment guard requiring `srv-noctua`, unless an exceptional override is documented in the audit log.
+
+## Current M2 primary targets
+
+The current primary targets for the next M2 license/admissibility pass are:
+
+1. `tigerline_roads_state_or_county`;
+2. `arxiv_metadata_hepth_astroph_reconstruction`;
+3. `ogbn_arxiv_undirected_projection`.
+
+This priority follows the M2 probe result that kept every family non-admitted while identifying these three as the primary next targets for manual license snapshot and candidate-level review.
+
 ## Admission rule
 
 A replacement graph may be promoted only after a later issue records:

--- a/data/instances/real/REAL_GRAPH_CURATION_ENVIRONMENT_POLICY.md
+++ b/data/instances/real/REAL_GRAPH_CURATION_ENVIRONMENT_POLICY.md
@@ -1,0 +1,68 @@
+# Real-graph curation environment policy
+
+This file records the operational environment policy for the real-graph replacement path after the SNAP classic exclusion decision.
+
+## Policy
+
+The dedicated server `srv-noctua` is the preferred and normative execution environment for any real-graph curation step that may produce experimental or data-derived artifacts.
+
+This includes:
+
+- downloading raw external data;
+- generating raw-source hashes;
+- generating derived graph artifacts;
+- validating graph structure at non-trivial scale;
+- computing morphology descriptors;
+- running M3 smoke tests;
+- running M4 confirmatory benchmarks;
+- running fixed-target, TTT, ECDF or attainment analyses;
+- training or validating CART gatekeeper models from benchmark outputs.
+
+The local WSL environment may be used for:
+
+- documentation-only patches;
+- Git and PR operations;
+- issue management;
+- reading audit logs;
+- commands that do not download data, create derived graph artifacts, run benchmarks or train models.
+
+## Rationale
+
+The purpose is to reduce avoidable environmental noise from WSL, filesystem differences, dependency differences and local resource constraints.
+
+The benchmark and any data-producing curation stages should therefore be aligned with the same dedicated environment used for confirmatory execution.
+
+## Required guard
+
+Any future script that downloads data, hashes raw artifacts, derives graphs, validates non-trivial graph structure, runs M3/M4 or trains CART should include an explicit environment guard.
+
+The guard should either:
+
+- require `hostname` to match `srv-noctua`; or
+- require a deliberate override variable such as `ALLOW_NON_NOCTUA_REALGRAPH_EXECUTION=1`, with the override printed in the audit log.
+
+The override should be exceptional and documented.
+
+## Current M2 primary targets
+
+The next M2 license/admissibility targets are:
+
+1. `tigerline_roads_state_or_county`;
+2. `arxiv_metadata_hepth_astroph_reconstruction`;
+3. `ogbn_arxiv_undirected_projection`.
+
+These targets are not admitted to M3 or M4 by this policy. Each still requires a candidate-level license snapshot, transformation record and review decision.
+
+## Non-goals
+
+This policy does not admit any replacement graph to execution.
+
+It also does not:
+
+- download any dataset;
+- produce raw or derived graph artifacts;
+- edit monograph prose;
+- add benchmark-result claims;
+- modify `decisions/08_Results_to_Text_Map.md`.
+
+Issue `#143` remains open until concrete replacement candidates are curated and either admitted for M3 smoke or explicitly rejected.


### PR DESCRIPTION
## Summary

Records the `srv-noctua`-first operational policy for real-graph replacement curation and the next M2 primary targets.

This PR updates/adds:

- `data/instances/real/REAL_GRAPH_CURATION_ENVIRONMENT_POLICY.md`;
- `data/instances/real/LICENSE_CLEAR_REPLACEMENT_CURATION.md`.

## What this does

- Makes `srv-noctua` the preferred and normative execution environment for real-graph curation steps that produce experimental or data-derived artifacts.
- Restricts WSL/local use to documentation, Git/PR, issue management, audit-log reading and non-data-producing commands.
- Requires future data-producing scripts to include an explicit environment guard for `srv-noctua`, with exceptional override via `ALLOW_NON_NOCTUA_REALGRAPH_EXECUTION=1`.
- Records the current M2 primary targets:
  - `tigerline_roads_state_or_county`;
  - `arxiv_metadata_hepth_astroph_reconstruction`;
  - `ogbn_arxiv_undirected_projection`.

## Conservative boundary

This PR does not admit any replacement graph to M3/M4 execution.

It does not:

- download any dataset;
- compute hashes;
- derive graphs;
- run M3/M4;
- train CART;
- edit monograph prose;
- add benchmark-result claims;
- modify `decisions/08_Results_to_Text_Map.md`.

## Rationale

The policy reduces avoidable noise from WSL, filesystem differences, dependency differences and local resource constraints. Data-producing real-graph curation should be aligned with the same dedicated environment intended for confirmatory execution.

## Validation

- srv-noctua-first policy validation passed.
- Pre-commit passed, including smoke tests.
- Only the environment policy and shortlist-curation documentation changed.
- No raw graph, cache/tmp/results, `.tex`, `.bib`, current SNAP manifest, `decisions/08_Results_to_Text_Map.md`, or `audit_reports/` path was changed.

Refs #143.
