### PR TITLE
docs: record ogbn-arxiv ODC-BY terms snapshot

### DIFF
--- a/data/instances/real/m2_license_snapshots/PROBE_EVIDENCE_INDEX.md
+++ b/data/instances/real/m2_license_snapshots/PROBE_EVIDENCE_INDEX.md
@@ -13,7 +13,9 @@ The relevant probes are:
 - `1016_noctua_m2_primary_license_snapshot_probe_no_remote_gh`;
 - `1025_noctua_focused_ogbn_arxiv_license_context_probe`;
 - `1026_noctua_ogbn_arxiv_section_boundary_license_probe`;
-- `1027_noctua_hash_ogbn_license_probe_artifacts`.
+- `1027_noctua_hash_ogbn_license_probe_artifacts`;
+- `1032_noctua_odc_by_terms_snapshot_probe`;
+- `1033_noctua_hash_odc_by_terms_probe_artifacts`.
 
 Execution environment:
 
@@ -45,6 +47,25 @@ The following ignored audit artifacts remain outside Git under `/audit_reports/`
 | `audit_reports/confirmatory_plan_956/1026_noctua_ogbn_arxiv_section_boundary_license_probe.json` | `cd80159f05c5c7d7aa31ef4e5df59c40af5f7a05b39dea995bcdd162e119806d` | structured section-boundary evidence |
 | `audit_reports/confirmatory_plan_956/1026_noctua_ogbn_arxiv_section_boundary_license_probe.md` | `1e850a8a5dc7b738bb1e1b2afa7cd3fbff3b9f2fc37b6fd3f8ce3accf571d639` | human-readable section-boundary summary |
 
+### ODC-BY terms and OGB source snapshot
+
+| artifact | sha256 | role |
+|---|---|---|
+| `audit_reports/confirmatory_plan_956/1032_noctua_odc_by_terms_snapshot_probe.remote.txt` | `c4ab03e8f3452f0fa9a15ff959f596f7a27eee48343a2735a827686ada34a436` | full terminal log of ODC-BY terms snapshot probe |
+| `audit_reports/confirmatory_plan_956/1032_noctua_odc_by_terms_snapshot_probe.json` | `9c23e740c5a856a4c9d8f046320f1d851a347910bfb23521db9d8b1177353e24` | structured ODC-BY terms and OGB page snapshot evidence |
+| `audit_reports/confirmatory_plan_956/1032_noctua_odc_by_terms_snapshot_probe.md` | `b4ddd59662c7830edc72f35674e21a350747b7ec810391623d3f6cd10d65340f` | human-readable ODC-BY terms snapshot summary |
+| `audit_reports/confirmatory_plan_956/1033_noctua_hash_odc_by_terms_probe_artifacts.remote.txt` | `0dc25414aeaf3f8b63ec7303b91dcd8afe4342a1bdb45003feb46a29d9f58b94` | full terminal log of hash inventory for 1032 artifacts |
+| `audit_reports/confirmatory_plan_956/1033_noctua_hash_odc_by_terms_probe_artifacts.json` | `1c1316fbb6a3eddfac6e60539807bf4080dd9a98ef6662b2c9d9f7a4bdc224f7` | structured hash inventory for 1032 artifacts |
+| `audit_reports/confirmatory_plan_956/1033_noctua_hash_odc_by_terms_probe_artifacts.md` | `3661f3c549f098d3811246b485f4a9db4b3342e5cd30a9c7a1273d19c86e604c` | human-readable hash inventory for 1032 artifacts |
+
+### Page snapshots from 1032
+
+| URL | HTTP | SHA256 | text_length | role |
+|---|---:|---|---:|---|
+| `https://opendatacommons.org/licenses/by/1-0/` | `200` | `681a60875b4d6e125401054eb50d8968374268e808952b1ec640a73f85cfcf1d` | `21384` | authoritative ODC-BY terms page |
+| `https://opendatacommons.org/licenses/by/1-0/index.html` | `200` | `681a60875b4d6e125401054eb50d8968374268e808952b1ec640a73f85cfcf1d` | `21384` | equivalent ODC-BY terms page |
+| `https://ogb.stanford.edu/docs/nodeprop/#ogbn-arxiv` | `200` | `00c8d645665e0d2dc1c643872b46f9f34c9fd9c469736fdf3e54b34c881c1b2f` | `15005` | OGB node property dataset documentation snapshot |
+
 ## Evidence used by current manifests
 
 ### `arxiv_metadata_hepth_astroph_reconstruction`
@@ -66,6 +87,9 @@ Current interpretation:
 
 - promising M2 replacement path;
 - current license expectation is ODC-BY;
+- exact ODC-BY terms snapshot is recorded from `https://opendatacommons.org/licenses/by/1-0/`;
+- exact OGB `ogbn-arxiv` documentation snapshot is recorded from `https://ogb.stanford.edu/docs/nodeprop/#ogbn-arxiv`;
+- ODC-BY attribution obligations must be satisfied before any M3 promotion;
 - the earlier CC0 interpretation was superseded by the `1026` section-boundary probe;
 - `1025` found mixed context requiring manual review;
 - `1026` isolated the section from `Dataset ogbn-arxiv` to the next dataset heading and inferred `License: ODC-BY`;
@@ -91,4 +115,4 @@ This index does not:
 - add benchmark-result claims;
 - modify `decisions/08_Results_to_Text_Map.md`.
 
-A later issue must still record final admission or rejection, exact acquisition procedure, transformation procedure, hashes when applicable, ODC-BY attribution handling and holdout grouping before M3 smoke execution.
+A later issue must still record final admission or rejection, exact acquisition procedure, transformation procedure, raw and derived hashes when applicable, exact ODC-BY attribution text, redistribution policy and holdout grouping before M3 smoke execution.

--- a/data/instances/real/m2_license_snapshots/ogbn_arxiv_undirected_projection.yaml
+++ b/data/instances/real/m2_license_snapshots/ogbn_arxiv_undirected_projection.yaml
@@ -15,21 +15,49 @@ official_source:
   hash_inventory: "1027_noctua_hash_ogbn_license_probe_artifacts"
   access_host: "srv-noctua"
   latest_review_date_utc: "2026-05-16"
+  odc_by_terms_probe: "1032_noctua_odc_by_terms_snapshot_probe"
+  odc_by_terms_hash_inventory: "1033_noctua_hash_odc_by_terms_probe_artifacts"
 
 license:
   expected_name: "Open Data Commons Attribution License (ODC-BY)"
   scope: "dataset entry for ogbn-arxiv, pending exact authoritative snapshot"
-  license_url: "pending_exact_snapshot"
+  license_url: "https://opendatacommons.org/licenses/by/1-0/"
+  exact_terms_snapshot:
+    source_probe: "1032_noctua_odc_by_terms_snapshot_probe"
+    hash_inventory: "1033_noctua_hash_odc_by_terms_probe_artifacts"
+    odc_by_url: "https://opendatacommons.org/licenses/by/1-0/"
+    odc_by_index_url: "https://opendatacommons.org/licenses/by/1-0/index.html"
+    odc_by_body_sha256: "681a60875b4d6e125401054eb50d8968374268e808952b1ec640a73f85cfcf1d"
+    odc_by_text_length: 21384
+    ogb_ogbn_arxiv_url: "https://ogb.stanford.edu/docs/nodeprop/#ogbn-arxiv"
+    ogb_ogbn_arxiv_body_sha256: "00c8d645665e0d2dc1c643872b46f9f34c9fd9c469736fdf3e54b34c881c1b2f"
+    ogb_ogbn_arxiv_text_length: 15005
   evidence_summary:
     - "The 1016 probe initially suggested a possible CC0 interpretation because a CC-0 mention appeared near the ogbn-arxiv text."
     - "The 1025 focused context probe classified the ogbn-arxiv license context as mixed and did not admit the candidate."
     - "The 1026 section-boundary probe isolated the section from 'Dataset ogbn-arxiv' to the next dataset heading and inferred License: ODC-BY for ogbn-arxiv."
     - "The 1027 inventory recorded hashes for the 1025 and 1026 audit artifacts and marked the prior CC0 correction as superseded by the 1026 section-boundary probe."
+    - "The 1032 probe snapshotted the ODC-BY terms and the OGB ogbn-arxiv source page; the 1033 inventory recorded hashes for those audit artifacts."
   expectation_revision:
     original_shortlist_expectation: "ODC_BY_expected_from_OGB_dataset_documentation"
     temporary_revision_after_1016: "CC0_expected_from_OGB_dataset_documentation_after_1016_probe"
     current_expectation_after_1026: "ODC_BY_supported_by_1026_section_boundary_probe"
     rationale: "The CC-0 mention belongs to the neighboring section context, while the isolated ogbn-arxiv section ends with License: ODC-BY."
+  attribution_obligations:
+    preliminary_status: "must_be_satisfied_before_m3_promotion"
+    evidence_basis:
+      - "The 1032 ODC-BY terms snapshot records that ODC-BY permits sharing, modification and use of the database subject to attribution requirements."
+      - "The 1032 snapshot records ODC-BY Section 4-style notice language requiring notice that content was obtained from the database and is available under the ODC Attribution License."
+      - "The 1032 snapshot also records that ODC-BY governs database rights and may not cover individual contents independently."
+    required_notice_template: "Contains information from OGB ogbn-arxiv, made available under the ODC Attribution License. See https://ogb.stanford.edu/docs/nodeprop/#ogbn-arxiv and https://opendatacommons.org/licenses/by/1-0/."
+    required_before_m3:
+      - "Confirm exact OGB dataset-level attribution wording, if any."
+      - "Record citation for the OGB benchmark and the MAG/arXiv source references used by OGB."
+      - "Record whether derived undirected projection must carry the same ODC-BY notice."
+      - "Record whether raw OGB files may be redistributed, or only acquired through scripts."
+      - "Record citation and attribution text in any generated metadata manifest."
+    redistribution_policy: "raw and derived redistribution remain disabled until a later explicit admission issue"
+
   restrictions_or_boundaries:
     - "Do not infer that the OGB software MIT license covers the dataset."
     - "Do not infer that licenses of neighboring OGB datasets apply to ogbn-arxiv."


### PR DESCRIPTION
## Summary

Records exact ODC-BY terms and OGB `ogbn-arxiv` source snapshots for the M2 license review.

This PR updates:

- `data/instances/real/m2_license_snapshots/PROBE_EVIDENCE_INDEX.md`;
- `data/instances/real/m2_license_snapshots/ogbn_arxiv_undirected_projection.yaml`.

## What this does

- Records the `1032` ODC-BY terms snapshot probe.
- Records the `1033` hash inventory for the `1032` artifacts.
- Adds the ODC-BY terms page hash.
- Adds the OGB `ogbn-arxiv` documentation page hash.
- Adds preliminary attribution obligations that must be satisfied before M3 promotion.
- Keeps raw and derived redistribution disabled until a later explicit admission issue.
- Keeps `ogbn-arxiv` pending M2 review and not admitted to M3/M4.

## Conservative boundary

This PR does not admit any replacement graph to M3/M4 execution.

It does not:

- download raw datasets;
- derive graphs;
- compute raw or derived graph hashes;
- authorize dataset redistribution;
- run M3/M4;
- train CART;
- edit monograph prose;
- add benchmark-result claims;
- modify `decisions/08_Results_to_Text_Map.md`.

## Claim boundary

The current license expectation for `ogbn-arxiv` remains ODC-BY. This PR strengthens the M2 evidence trail by recording exact documentation snapshots and attribution obligations, but it is not an execution whitelist.

A later issue must still record final admission or rejection, exact acquisition procedure, transformation procedure, raw and derived hashes when applicable, exact ODC-BY attribution text, redistribution policy and holdout grouping before M3 smoke execution.

## Validation

- OGBN ODC-BY terms snapshot validation passed.
- Pre-commit passed, including smoke tests.
- Only the expected M2 ODC-BY evidence files changed.
- No raw graph, cache/tmp/results, `.tex`, `.bib`, current SNAP manifest, result-map, or `audit_reports/` path was changed.

Refs #143.
