### PR TITLE
docs: record ogbn-arxiv reproducer postmerge validation

### DIFF
--- a/data/instances/real/m2_license_snapshots/ogbn_arxiv_undirected_projection.yaml
+++ b/data/instances/real/m2_license_snapshots/ogbn_arxiv_undirected_projection.yaml
@@ -114,3 +114,28 @@ m3_smoke_completion_after_1050:
   benchmark_run: false
   cart_training_run: false
   monograph_result_claim_supported: false
+
+versioned_reproducer_after_1064:
+  status: "merged_and_validated_not_m4"
+  pr: 153
+  merge_commit: "6cc45206994af72b0df7dbbeb8e9b90d21cbdfba"
+  postmerge_validation_probe: "1064_close_pr153_postmerge_validation_without_remote_gh"
+  noctua_synced_to_merge_commit: true
+  script_path: "scripts/real_graphs/prepare_ogbn_arxiv_undirected_projection.py"
+  readme_path: "scripts/real_graphs/README.md"
+  python310_compatibility_guard_present: true
+  timestamp_strategy: "time.strftime_with_time.gmtime"
+  raw_inventory_verified: true
+  raw_file_count: 14
+  legacy_1049_projection_sha256: "5e3a7c7eea2ef66c46ca9091fc707c27bfd8f0844bacea29d427299d8e3fcf8c"
+  versioned_1061_reproducer_projection_sha256: "b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba"
+  versioned_1061_repeat_projection_sha256: "b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba"
+  versioned_reproducer_deterministic: true
+  projection_from_raw_csv: true
+  used_torch_load: false
+  used_ogb_processed_cache_for_projection: false
+  m4_benchmark_admitted: false
+  benchmark_run: false
+  cart_training_run: false
+  monograph_result_claim_supported: false
+  m4_gate_status: "blocked_pending_explicit_gate_decision"

--- a/data/instances/real/m3_smoke_admissions/README.md
+++ b/data/instances/real/m3_smoke_admissions/README.md
@@ -57,3 +57,19 @@ Boundary:
 - no benchmark campaign was run;
 - no CART training was run;
 - no monograph result claim is supported.
+
+## ogbn-arxiv versioned reproducer after PR 153
+
+The raw-CSV projection reproducer for `ogbn-arxiv` was merged through PR `#153` at commit `6cc45206994af72b0df7dbbeb8e9b90d21cbdfba`.
+
+Post-merge validation `1064` confirmed on `srv-noctua` that:
+
+- the merged reproducer is present;
+- the Python 3.10-compatible timestamp guard is present;
+- the 14-file raw inventory remains verified;
+- the legacy M3 projection hash remains `5e3a7c7eea2ef66c46ca9091fc707c27bfd8f0844bacea29d427299d8e3fcf8c`;
+- the versioned reproducer projection hash is `b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba`;
+- the repeated reproducer projection hash matches the first reproducer run;
+- M4 benchmark, benchmark campaigns, CART training and monograph result claims remain blocked.
+
+This record documents reproducibility of the M3 validation procedure. It does not admit `ogbn-arxiv` to M4.

--- a/data/instances/real/m3_smoke_admissions/ogbn_arxiv_undirected_projection_m3_smoke_admission.yaml
+++ b/data/instances/real/m3_smoke_admissions/ogbn_arxiv_undirected_projection_m3_smoke_admission.yaml
@@ -107,3 +107,28 @@ m3_smoke_completion_after_1050:
   m4_benchmark_blocked_until_later_gate: true
   benchmark_run: false
   cart_training_run: false
+
+versioned_reproducer_after_1064:
+  status: "merged_and_validated_not_m4"
+  pr: 153
+  merge_commit: "6cc45206994af72b0df7dbbeb8e9b90d21cbdfba"
+  postmerge_validation_probe: "1064_close_pr153_postmerge_validation_without_remote_gh"
+  noctua_synced_to_merge_commit: true
+  script_path: "scripts/real_graphs/prepare_ogbn_arxiv_undirected_projection.py"
+  readme_path: "scripts/real_graphs/README.md"
+  python310_compatibility_guard_present: true
+  timestamp_strategy: "time.strftime_with_time.gmtime"
+  raw_inventory_verified: true
+  raw_file_count: 14
+  legacy_1049_projection_sha256: "5e3a7c7eea2ef66c46ca9091fc707c27bfd8f0844bacea29d427299d8e3fcf8c"
+  versioned_1061_reproducer_projection_sha256: "b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba"
+  versioned_1061_repeat_projection_sha256: "b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba"
+  versioned_reproducer_deterministic: true
+  projection_from_raw_csv: true
+  used_torch_load: false
+  used_ogb_processed_cache_for_projection: false
+  m4_benchmark_admitted: false
+  benchmark_run: false
+  cart_training_run: false
+  monograph_result_claim_supported: false
+  m4_gate_status: "blocked_pending_explicit_gate_decision"

--- a/data/instances/real/m3_smoke_admissions/ogbn_arxiv_undirected_projection_m3_smoke_evidence.yaml
+++ b/data/instances/real/m3_smoke_admissions/ogbn_arxiv_undirected_projection_m3_smoke_evidence.yaml
@@ -212,3 +212,28 @@ guardrails:
   - "This evidence file does not support monograph result claims."
   - "Raw and derived files remain local-only and ignored."
   - "No raw or derived graph file may be committed by this patch."
+
+versioned_reproducer_after_1064:
+  status: "merged_and_validated_not_m4"
+  pr: 153
+  merge_commit: "6cc45206994af72b0df7dbbeb8e9b90d21cbdfba"
+  postmerge_validation_probe: "1064_close_pr153_postmerge_validation_without_remote_gh"
+  noctua_synced_to_merge_commit: true
+  script_path: "scripts/real_graphs/prepare_ogbn_arxiv_undirected_projection.py"
+  readme_path: "scripts/real_graphs/README.md"
+  python310_compatibility_guard_present: true
+  timestamp_strategy: "time.strftime_with_time.gmtime"
+  raw_inventory_verified: true
+  raw_file_count: 14
+  legacy_1049_projection_sha256: "5e3a7c7eea2ef66c46ca9091fc707c27bfd8f0844bacea29d427299d8e3fcf8c"
+  versioned_1061_reproducer_projection_sha256: "b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba"
+  versioned_1061_repeat_projection_sha256: "b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba"
+  versioned_reproducer_deterministic: true
+  projection_from_raw_csv: true
+  used_torch_load: false
+  used_ogb_processed_cache_for_projection: false
+  m4_benchmark_admitted: false
+  benchmark_run: false
+  cart_training_run: false
+  monograph_result_claim_supported: false
+  m4_gate_status: "blocked_pending_explicit_gate_decision"

--- a/scripts/real_graphs/README.md
+++ b/scripts/real_graphs/README.md
@@ -28,3 +28,12 @@ Example validation run on srv-noctua:
       --output-dir data/tmp/real_graph_m3_smoke/ogbn_arxiv/derived/1057_versioned_reproducer_probe
 
 The output is still a local validation artifact. A later explicit M4 gate is required before using any projection as benchmark input.
+
+## Post-merge validation status
+
+PR `#153` merged this reproducer at commit `6cc45206994af72b0df7dbbeb8e9b90d21cbdfba`.
+
+The `1064` post-merge validation on `srv-noctua` confirmed that the merged script is present, keeps Python 3.10-compatible timestamp handling, verifies the 14-file raw inventory, and reproduces the deterministic local projection artifact from the raw CSV inputs.
+The validated deterministic reproducer projection SHA256 is `b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba`.
+
+This validation does not admit M4 benchmark execution. M4 benchmark execution remains blocked; the output remains a local ignored validation artifact until a later explicit M4 gate decision.


### PR DESCRIPTION
## Summary

Records the post-merge validation of the `ogbn-arxiv` raw-CSV reproducer merged through PR #153.

This documents that the merged reproducer was validated on `srv-noctua` after the Python 3.10 timestamp compatibility fix.

## Evidence recorded

- PR #153 merge commit: `6cc45206994af72b0df7dbbeb8e9b90d21cbdfba`
- Post-merge validation probe: `1064_close_pr153_postmerge_validation_without_remote_gh`
- Raw file inventory count: `14`
- Legacy M3 projection SHA256: `5e3a7c7eea2ef66c46ca9091fc707c27bfd8f0844bacea29d427299d8e3fcf8c`
- Versioned reproducer projection SHA256: `b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba`
- Repeat reproducer projection SHA256: `b6533424c1f0b226127130697c7effbab2c1dbfd07c8ed48f0468bbc46e290ba`

## Conservative boundary

This PR does not:

- admit M4 benchmark execution;
- run benchmark campaigns;
- train CART;
- authorize raw or derived redistribution;
- modify monograph result claims;
- commit raw or derived graph artifacts;
- modify `decisions/08_Results_to_Text_Map.md`.

M4 remains blocked pending an explicit later gate decision.

Refs #143.
